### PR TITLE
Harden multi-network Wave settings (Horizon/Soroban network mismatch detection)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,4 +33,6 @@ SOROBAN_CONTRACT_ID=
 
 # Optional: Soroban RPC endpoint used by the event timeline panel.
 # Defaults to https://soroban-testnet.stellar.org if unset.
+# Keep on the same network as NEXT_PUBLIC_HORIZON_URL above — a mismatch
+# (e.g. leaving both unset) is detected and surfaced on the dashboard.
 SOROBAN_RPC_URL=

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": ["next/core-web-vitals", "next/typescript"]
 }

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ All docs are cross-linked from this README:
 | `/api/stats` | GET | Aggregate readiness statistics |
 | `/api/actions/lookup` | GET | Cached Horizon readiness lookup + wizard `nextAction` guidance, `?address=G...` |
 | `/api/soroban/events` | GET | Recent events for `SOROBAN_CONTRACT_ID` (maintainer only) |
+| `/api/settings/network` | GET | Resolved Horizon/Soroban network + mismatch warnings (maintainer only) |
 
 ### Middleware
 
@@ -176,6 +177,8 @@ NEXT_PUBLIC_MIN_XLM_BALANCE=1
 SOROBAN_CONTRACT_ID=   # optional, future on-chain registry + event timeline panel
 SOROBAN_RPC_URL=       # optional, defaults to soroban-testnet.stellar.org
 ```
+
+> **Note:** `NEXT_PUBLIC_HORIZON_URL` and `SOROBAN_RPC_URL` should point at the same Stellar network. Their defaults don't (mainnet vs. testnet) — the dashboard detects and warns on this mismatch via `/api/settings/network` and the maintainer dashboard's network status panel, and records it to the audit log.
 
 See [docs/ENVIRONMENT.md](./docs/ENVIRONMENT.md) for details.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -210,7 +210,7 @@ Key components:
 - **Tokens encrypted at rest** — `User.accessToken` is AES-256-GCM ciphertext; sign-in fails closed (stores nothing) if `TOKEN_ENCRYPTION_KEY` is missing or malformed rather than falling back to plaintext
 - **No client-side access tokens** — the GitHub access token never appears on the NextAuth JWT or `session` object; it exists only encrypted in PostgreSQL, decrypted on demand server-side via `getDecryptedGithubAccessToken()`
 - **Horizon calls server-side** — `/api/check` and `/api/actions/lookup` prevent CORS/rate-limit issues and keep validation logic centralized
-- **Maintainer API guard** — `/api/contributors` and `/api/soroban/events` verify `isMaintainer` on every request
+- **Maintainer API guard** — `/api/contributors`, `/api/soroban/events`, and `/api/settings/network` verify `isMaintainer` on every request
 - **Address uniqueness** — prevents duplicate payout mappings
 
 ---
@@ -224,6 +224,20 @@ Key components:
 ## Soroban event timeline
 
 The maintainer dashboard's **Soroban event timeline** panel (`src/components/SorobanEventTimeline.tsx`) shows recent contract events for `SOROBAN_CONTRACT_ID`, fetched server-side via `getSorobanEventTimeline()` (`src/lib/soroban.ts`) using `stellar-sdk`'s Soroban RPC client (`SOROBAN_RPC_URL`, default `soroban-testnet.stellar.org`). Exposed through `GET /api/soroban/events` (maintainer-only). RPC outages, rate limits, or a missing `SOROBAN_CONTRACT_ID` never throw — they surface as an `errors` array the panel renders inline, with an empty event list.
+
+---
+
+## Network hardening
+
+Horizon and Soroban RPC network selection is env-var driven (`NEXT_PUBLIC_HORIZON_URL`, `SOROBAN_RPC_URL`) with independent defaults that do not agree with each other — Horizon defaults to **mainnet**, Soroban RPC defaults to **testnet**. Left unchecked, this lets a maintainer validate contributor funding against one network while reading Soroban events from another with no indication anything is wrong.
+
+[`src/lib/network-config.ts`](../src/lib/network-config.ts) classifies each resolved URL by hostname (`mainnet` / `testnet` / `custom`) and flags `mismatched: true` only when both URLs resolve to two different *known* named networks — a custom or self-hosted RPC endpoint on either side is never treated as a false positive, since it cannot be confidently classified.
+
+- **API:** `GET /api/settings/network` (maintainer-only) returns the current classification and any warnings.
+- **UI:** the `NetworkStatusPanel` component (`src/components/NetworkStatusPanel.tsx`) renders on `/dashboard`, showing the Horizon/Soroban network badges and a warning banner when mismatched.
+- **Audit trail:** a mismatch writes a `network_config_mismatch_detected` entry to the existing `AuditLog` table via `recordAuditLog()`, visible through `GET /api/audit`.
+
+This is intentionally read-only and additive — it surfaces the misconfiguration rather than attempting to auto-correct it, since the "right" network is a deployment decision, not something the dashboard can infer.
 
 ---
 

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -95,6 +95,8 @@ Horizon API base URL.
 
 Must match the network your contributors use.
 
+> **Network consistency:** `NEXT_PUBLIC_HORIZON_URL` and `SOROBAN_RPC_URL` (below) should point at the **same** Stellar network. The project's own defaults do not — Horizon defaults to mainnet while `SOROBAN_RPC_URL` defaults to testnet — so a maintainer who only sets one of the two can end up validating contributor funding against a different network than the one Soroban events are read from. The dashboard detects this: `GET /api/settings/network` (maintainer-only) and the "Network configuration" panel on `/dashboard` compare the resolved networks and show a warning banner when they mismatch, and a `network_config_mismatch_detected` entry is written to the audit log (visible via `GET /api/audit`) so the misconfiguration has a durable record. See [`src/lib/network-config.ts`](../src/lib/network-config.ts).
+
 ### `NEXT_PUBLIC_DEFAULT_ASSET_CODE`
 
 Asset code for trustline checks. Default: `USDC`
@@ -133,6 +135,8 @@ Soroban RPC endpoint used to fetch contract events for the timeline panel. Defau
 |---------|-----|
 | Mainnet | `https://mainnet.sorobanrpc.com` |
 | Testnet | `https://soroban-testnet.stellar.org` |
+
+**Keep this on the same network as `NEXT_PUBLIC_HORIZON_URL` above.** The default here is testnet while the default Horizon URL is mainnet — see the network consistency note above and [Architecture — network hardening](./ARCHITECTURE.md#network-hardening) for how the mismatch is surfaced.
 
 ---
 

--- a/src/app/api/contributors/route.ts
+++ b/src/app/api/contributors/route.ts
@@ -1,7 +1,8 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 
 import { requireMaintainerSession } from "@/lib/api-auth";
 import { recordAuditLog } from "@/lib/audit";
+import { assertSameOrigin } from "@/lib/csrf";
 import { getContributors, refreshAllContributors } from "@/lib/registrations";
 
 export const runtime = "nodejs";
@@ -16,7 +17,10 @@ export async function GET() {
   return NextResponse.json({ contributors });
 }
 
-export async function POST() {
+export async function POST(request: NextRequest) {
+  const csrf = assertSameOrigin(request);
+  if (csrf) return csrf;
+
   const session = await requireMaintainerSession();
   if (!session) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });

--- a/src/app/api/register/route.ts
+++ b/src/app/api/register/route.ts
@@ -4,6 +4,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { recordAuditLog } from "@/lib/audit";
 import { authOptions } from "@/lib/auth";
 import { DEFAULT_ASSET } from "@/lib/constants";
+import { assertSameOrigin } from "@/lib/csrf";
 import { checkStellarAddress } from "@/lib/horizon";
 import { prisma } from "@/lib/prisma";
 import { isValidStellarAddress } from "@/lib/stellar";

--- a/src/app/api/settings/network/route.ts
+++ b/src/app/api/settings/network/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from "next/server";
+
+import { requireMaintainerSession } from "@/lib/api-auth";
+import { recordAuditLog } from "@/lib/audit";
+import { getNetworkConfig } from "@/lib/network-config";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * Maintainer-only view of the resolved Horizon/Soroban network
+ * configuration. Records an audit entry when a mismatch is detected so
+ * there is a durable trail even if nobody happens to be looking at the
+ * dashboard when a misconfiguration ships.
+ */
+export async function GET() {
+  const session = await requireMaintainerSession();
+  if (!session) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const config = getNetworkConfig();
+
+  if (config.mismatched) {
+    await recordAuditLog({
+      action: "network_config_mismatch_detected",
+      actorId: session.user.id,
+      actorLogin: session.user.githubUsername ?? null,
+      targetLabel: "network-config",
+      metadata: {
+        horizonNetwork: config.horizonNetwork,
+        sorobanNetwork: config.sorobanNetwork,
+        horizonUrl: config.horizonUrl,
+        sorobanUrl: config.sorobanUrl,
+      },
+    });
+  }
+
+  return NextResponse.json(config);
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -7,6 +7,7 @@ import {
   ContributorTable,
   exportContributorsCsv,
 } from "@/components/ContributorTable";
+import { NetworkStatusPanel } from "@/components/NetworkStatusPanel";
 import { SorobanEventTimeline } from "@/components/SorobanEventTimeline";
 import { WaveReadinessBar } from "@/components/WaveReadinessBar";
 import { Button } from "@/components/ui/button";
@@ -18,7 +19,11 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { countReadyContributors } from "@/lib/contributors";
-import type { ContributorRow, SorobanEventTimelineResponse } from "@/types";
+import type {
+  ContributorRow,
+  NetworkConfig,
+  SorobanEventTimelineResponse,
+} from "@/types";
 
 interface ContributorsResponse {
   contributors: ContributorRow[];
@@ -51,12 +56,41 @@ export default function DashboardPage() {
     },
   });
 
+  const recheckOneMutation = useMutation({
+    mutationFn: async (id: string) => {
+      const response = await fetch(`/api/contributors/${id}`, {
+        method: "POST",
+      });
+      if (!response.ok) throw new Error("Re-check failed");
+      return (await response.json()) as { contributor: ContributorRow };
+    },
+    onSuccess: (data) => {
+      queryClient.setQueryData<ContributorsResponse>(
+        ["contributors"],
+        (current) => ({
+          contributors: (current?.contributors ?? []).map((row) =>
+            row.id === data.contributor.id ? data.contributor : row
+          ),
+        })
+      );
+    },
+  });
+
   const sorobanQuery = useQuery({
     queryKey: ["soroban-events"],
     queryFn: async () => {
       const response = await fetch("/api/soroban/events");
       if (!response.ok) throw new Error("Failed to load Soroban events");
       return (await response.json()) as SorobanEventTimelineResponse;
+    },
+  });
+
+  const networkQuery = useQuery({
+    queryKey: ["network-config"],
+    queryFn: async () => {
+      const response = await fetch("/api/settings/network");
+      if (!response.ok) throw new Error("Failed to load network config");
+      return (await response.json()) as NetworkConfig;
     },
   });
 
@@ -86,6 +120,10 @@ export default function DashboardPage() {
           Re-check all
         </Button>
       </div>
+
+      {networkQuery.data && (
+        <NetworkStatusPanel config={networkQuery.data} className="mb-8" />
+      )}
 
       <Card className="mb-8">
         <CardHeader>

--- a/src/components/NetworkStatusPanel.tsx
+++ b/src/components/NetworkStatusPanel.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { AlertTriangle, CheckCircle2 } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import type { NetworkConfig, StellarNetwork } from "@/types";
+
+interface NetworkStatusPanelProps {
+  config: NetworkConfig;
+  className?: string;
+}
+
+const NETWORK_BADGE_VARIANT: Record<
+  StellarNetwork,
+  "ready" | "warning" | "secondary"
+> = {
+  mainnet: "ready",
+  testnet: "secondary",
+  custom: "warning",
+};
+
+const NETWORK_LABEL: Record<StellarNetwork, string> = {
+  mainnet: "Mainnet",
+  testnet: "Testnet",
+  custom: "Custom",
+};
+
+export function NetworkStatusPanel({
+  config,
+  className,
+}: NetworkStatusPanelProps) {
+  const { horizonNetwork, sorobanNetwork, mismatched, warnings } = config;
+
+  return (
+    <Card
+      className={cn(
+        mismatched
+          ? "border-destructive/40 bg-destructive/5"
+          : "border-stellar-cyan/20 bg-gradient-to-br from-stellar-purple/5 to-stellar-cyan/5",
+        className
+      )}
+    >
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-lg">
+          {mismatched ? (
+            <AlertTriangle className="h-5 w-5 text-destructive" />
+          ) : (
+            <CheckCircle2 className="h-5 w-5 text-emerald-500" />
+          )}
+          Network configuration
+        </CardTitle>
+        <CardDescription>
+          The Stellar network the dashboard is validating contributor
+          funding and Soroban events against.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3 text-sm">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-muted-foreground">Horizon:</span>
+          <Badge variant={NETWORK_BADGE_VARIANT[horizonNetwork]}>
+            {NETWORK_LABEL[horizonNetwork]}
+          </Badge>
+          <span className="flex items-center gap-2">
+            <span className="text-muted-foreground">Soroban RPC:</span>
+            <Badge variant={NETWORK_BADGE_VARIANT[sorobanNetwork]}>
+              {NETWORK_LABEL[sorobanNetwork]}
+            </Badge>
+          </span>
+        </div>
+
+        {mismatched && (
+          <div className="rounded-lg border border-destructive/30 bg-destructive/10 p-3 text-destructive">
+            <p className="font-semibold">Network mismatch detected</p>
+            <ul className="mt-1 list-disc space-y-1 pl-5">
+              {warnings.map((warning) => (
+                <li key={warning}>{warning}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {!mismatched &&
+          warnings.map((warning) => (
+            <p key={warning} className="text-muted-foreground">
+              {warning}
+            </p>
+          ))}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/lib/action-lookup.test.ts
+++ b/src/lib/action-lookup.test.ts
@@ -10,6 +10,8 @@ function result(overrides: Partial<HorizonCheckResult>): HorizonCheckResult {
   return {
     funded: false,
     trustline: false,
+    trustline_authorized: false,
+    verified: false,
     xlm_balance: "0",
     errors: [],
     readiness: "not_ready",

--- a/src/lib/audit-format.ts
+++ b/src/lib/audit-format.ts
@@ -6,6 +6,7 @@ export const AUDIT_ACTION_LABELS: Record<string, string> = {
   "recheck.batch": "Re-checked all contributors",
   "registration.create": "Registered a Stellar address",
   "registration.update": "Updated a Stellar address",
+  network_config_mismatch_detected: "Detected a Horizon/Soroban network mismatch",
 };
 
 export function describeAuditAction(action: string): string {

--- a/src/lib/batch-verify.test.ts
+++ b/src/lib/batch-verify.test.ts
@@ -10,7 +10,7 @@ import {
 
 function result(
   status: VerificationCheckResult["status"],
-  username = status
+  username: string = status
 ): VerificationCheckResult {
   return {
     username,

--- a/src/lib/network-config.test.ts
+++ b/src/lib/network-config.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  classifyHorizonNetwork,
+  classifySorobanNetwork,
+  getNetworkConfig,
+} from "@/lib/network-config";
+
+describe("classifyHorizonNetwork", () => {
+  it("classifies the canonical mainnet Horizon hostname", () => {
+    expect(classifyHorizonNetwork("https://horizon.stellar.org")).toBe(
+      "mainnet"
+    );
+  });
+
+  it("classifies the canonical testnet Horizon hostname", () => {
+    expect(
+      classifyHorizonNetwork("https://horizon-testnet.stellar.org")
+    ).toBe("testnet");
+  });
+
+  it("treats unrecognized hostnames as custom", () => {
+    expect(classifyHorizonNetwork("https://horizon.example.com")).toBe(
+      "custom"
+    );
+  });
+
+  it("treats an unparseable URL as custom rather than throwing", () => {
+    expect(classifyHorizonNetwork("not-a-url")).toBe("custom");
+  });
+});
+
+describe("classifySorobanNetwork", () => {
+  it("classifies the canonical testnet Soroban RPC hostname", () => {
+    expect(
+      classifySorobanNetwork("https://soroban-testnet.stellar.org")
+    ).toBe("testnet");
+  });
+
+  it("classifies the documented mainnet Soroban RPC hostname", () => {
+    expect(classifySorobanNetwork("https://mainnet.sorobanrpc.com")).toBe(
+      "mainnet"
+    );
+  });
+
+  it("treats unrecognized hostnames as custom (e.g. private RPC nodes)", () => {
+    expect(classifySorobanNetwork("https://rpc.myteam.internal")).toBe(
+      "custom"
+    );
+  });
+});
+
+describe("getNetworkConfig", () => {
+  const ORIGINAL_ENV = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    vi.unstubAllEnvs();
+  });
+
+  it("is not mismatched when both endpoints resolve to testnet", () => {
+    process.env.NEXT_PUBLIC_HORIZON_URL = "https://horizon-testnet.stellar.org";
+    process.env.SOROBAN_RPC_URL = "https://soroban-testnet.stellar.org";
+
+    const config = getNetworkConfig();
+
+    expect(config.horizonNetwork).toBe("testnet");
+    expect(config.sorobanNetwork).toBe("testnet");
+    expect(config.mismatched).toBe(false);
+  });
+
+  it("flags the project's actual default configuration as mismatched (Horizon mainnet vs Soroban testnet)", () => {
+    delete process.env.NEXT_PUBLIC_HORIZON_URL;
+    delete process.env.SOROBAN_RPC_URL;
+
+    const config = getNetworkConfig();
+
+    expect(config.horizonNetwork).toBe("mainnet");
+    expect(config.sorobanNetwork).toBe("testnet");
+    expect(config.mismatched).toBe(true);
+    expect(config.warnings.join(" ")).toMatch(/mainnet/i);
+  });
+
+  it("does not false-positive when both endpoints are custom URLs", () => {
+    process.env.NEXT_PUBLIC_HORIZON_URL = "https://horizon.myteam.internal";
+    process.env.SOROBAN_RPC_URL = "https://soroban.myteam.internal";
+
+    const config = getNetworkConfig();
+
+    expect(config.horizonNetwork).toBe("custom");
+    expect(config.sorobanNetwork).toBe("custom");
+    expect(config.mismatched).toBe(false);
+  });
+
+  it("does not false-positive when one endpoint is custom and the other is a named network", () => {
+    process.env.NEXT_PUBLIC_HORIZON_URL = "https://horizon.stellar.org";
+    process.env.SOROBAN_RPC_URL = "https://rpc.myteam.internal";
+
+    const config = getNetworkConfig();
+
+    expect(config.horizonNetwork).toBe("mainnet");
+    expect(config.sorobanNetwork).toBe("custom");
+    expect(config.mismatched).toBe(false);
+  });
+
+  it("reports sorobanContractConfigured based on SOROBAN_CONTRACT_ID", () => {
+    delete process.env.SOROBAN_CONTRACT_ID;
+    expect(getNetworkConfig().sorobanContractConfigured).toBe(false);
+
+    process.env.SOROBAN_CONTRACT_ID = "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC";
+    expect(getNetworkConfig().sorobanContractConfigured).toBe(true);
+  });
+});

--- a/src/lib/network-config.ts
+++ b/src/lib/network-config.ts
@@ -1,0 +1,101 @@
+import "server-only";
+
+import { DEFAULT_HORIZON_URL } from "@/lib/constants";
+import type { NetworkConfig, StellarNetwork } from "@/types";
+
+const DEFAULT_SOROBAN_RPC_URL = "https://soroban-testnet.stellar.org";
+
+/**
+ * Resolve the Horizon URL exactly as `getHorizonServer()` does in
+ * `src/lib/horizon.ts` — kept in sync deliberately rather than imported,
+ * since `horizon.ts` is a `server-only` module built around the SDK client
+ * and importing it here would pull in `stellar-sdk` for a pure classifier.
+ */
+export function resolveHorizonUrl(): string {
+  return process.env.NEXT_PUBLIC_HORIZON_URL?.trim() || DEFAULT_HORIZON_URL;
+}
+
+/** Mirrors `getSorobanRpcUrl()` in `src/lib/soroban.ts`. */
+export function resolveSorobanRpcUrl(): string {
+  return process.env.SOROBAN_RPC_URL?.trim() || DEFAULT_SOROBAN_RPC_URL;
+}
+
+/** Classify a Horizon URL by hostname. Unknown hosts are "custom". */
+export function classifyHorizonNetwork(url: string): StellarNetwork {
+  const hostname = safeHostname(url);
+  if (hostname === "horizon.stellar.org") return "mainnet";
+  if (hostname === "horizon-testnet.stellar.org") return "testnet";
+  return "custom";
+}
+
+/**
+ * Classify a Soroban RPC URL by hostname. There is no single canonical
+ * public mainnet Soroban RPC hostname the way there is for Horizon — most
+ * mainnet deployments use a provider-specific endpoint (e.g. a paid RPC
+ * service) rather than one blessed by the Stellar Development Foundation.
+ * `soroban-testnet.stellar.org` is the one hostname worth hardcoding with
+ * confidence; `mainnet.sorobanrpc.com` is documented in this project's own
+ * docs/ENVIRONMENT.md as the mainnet example, so it is special-cased too.
+ * Anything else is treated as "custom" rather than guessed at, so a
+ * self-hosted or private RPC node never false-positives as a network
+ * mismatch.
+ */
+export function classifySorobanNetwork(url: string): StellarNetwork {
+  const hostname = safeHostname(url);
+  if (hostname === "soroban-testnet.stellar.org") return "testnet";
+  if (hostname === "mainnet.sorobanrpc.com") return "mainnet";
+  return "custom";
+}
+
+function safeHostname(url: string): string {
+  try {
+    return new URL(url).hostname.toLowerCase();
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Reads the resolved Horizon and Soroban RPC endpoints and flags a
+ * mismatch when they point at two different *known* named networks (e.g.
+ * Horizon mainnet + Soroban testnet — the project's actual default
+ * configuration). Custom endpoints on either side are never flagged, since
+ * a private/self-hosted RPC node is a legitimate setup this check cannot
+ * confidently classify.
+ */
+export function getNetworkConfig(): NetworkConfig {
+  const horizonUrl = resolveHorizonUrl();
+  const sorobanUrl = resolveSorobanRpcUrl();
+  const horizonNetwork = classifyHorizonNetwork(horizonUrl);
+  const sorobanNetwork = classifySorobanNetwork(sorobanUrl);
+  const sorobanContractConfigured = Boolean(
+    process.env.SOROBAN_CONTRACT_ID?.trim()
+  );
+
+  const mismatched =
+    horizonNetwork !== "custom" &&
+    sorobanNetwork !== "custom" &&
+    horizonNetwork !== sorobanNetwork;
+
+  const warnings: string[] = [];
+  if (mismatched) {
+    warnings.push(
+      `Horizon is configured for ${horizonNetwork} (${horizonUrl}) but Soroban RPC is configured for ${sorobanNetwork} (${sorobanUrl}). Contributor funding and Soroban events are being read from different networks.`
+    );
+  }
+  if (!sorobanContractConfigured) {
+    warnings.push(
+      "SOROBAN_CONTRACT_ID is not configured — the Soroban event timeline is disabled."
+    );
+  }
+
+  return {
+    horizonUrl,
+    horizonNetwork,
+    sorobanUrl,
+    sorobanNetwork,
+    sorobanContractConfigured,
+    mismatched,
+    warnings,
+  };
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -42,7 +42,8 @@ export type AuditAction =
   | "recheck.single"
   | "recheck.batch"
   | "registration.create"
-  | "registration.update";
+  | "registration.update"
+  | "network_config_mismatch_detected";
 
 export interface AuditLogEntry {
   id: string;
@@ -78,4 +79,16 @@ export interface SorobanEventTimelineResponse {
   events: SorobanEventRow[];
   latestLedger: number;
   errors: string[];
+}
+
+export type StellarNetwork = "mainnet" | "testnet" | "custom";
+
+export interface NetworkConfig {
+  horizonUrl: string;
+  horizonNetwork: StellarNetwork;
+  sorobanUrl: string;
+  sorobanNetwork: StellarNetwork;
+  sorobanContractConfigured: boolean;
+  mismatched: boolean;
+  warnings: string[];
 }

--- a/tests/api/settings-network.test.ts
+++ b/tests/api/settings-network.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { GET } from "@/app/api/settings/network/route";
+
+vi.mock("next-auth", () => ({
+  getServerSession: vi.fn(),
+}));
+
+vi.mock("@/lib/audit", () => ({
+  recordAuditLog: vi.fn(),
+}));
+
+import { getServerSession } from "next-auth";
+import { recordAuditLog } from "@/lib/audit";
+
+const ORIGINAL_ENV = { ...process.env };
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+  vi.clearAllMocks();
+});
+
+describe("GET /api/settings/network", () => {
+  it("returns 403 for an unauthenticated request", async () => {
+    vi.mocked(getServerSession).mockResolvedValue(null);
+
+    const res = await GET();
+    expect(res.status).toBe(403);
+    const json = await res.json();
+    expect(json.error).toBe("Forbidden");
+    expect(recordAuditLog).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 for a non-maintainer session", async () => {
+    vi.mocked(getServerSession).mockResolvedValue({
+      user: { id: "user-1", isMaintainer: false },
+    } as any);
+
+    const res = await GET();
+    expect(res.status).toBe(403);
+    expect(recordAuditLog).not.toHaveBeenCalled();
+  });
+
+  it("returns 200 with network config for a maintainer and does not audit when networks match", async () => {
+    vi.mocked(getServerSession).mockResolvedValue({
+      user: { id: "user-1", isMaintainer: true, githubUsername: "octocat" },
+    } as any);
+    process.env.NEXT_PUBLIC_HORIZON_URL = "https://horizon-testnet.stellar.org";
+    process.env.SOROBAN_RPC_URL = "https://soroban-testnet.stellar.org";
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.mismatched).toBe(false);
+    expect(recordAuditLog).not.toHaveBeenCalled();
+  });
+
+  it("records an audit entry when a network mismatch is detected", async () => {
+    vi.mocked(getServerSession).mockResolvedValue({
+      user: { id: "user-1", isMaintainer: true, githubUsername: "octocat" },
+    } as any);
+    process.env.NEXT_PUBLIC_HORIZON_URL = "https://horizon.stellar.org";
+    process.env.SOROBAN_RPC_URL = "https://soroban-testnet.stellar.org";
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.mismatched).toBe(true);
+    expect(recordAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "network_config_mismatch_detected",
+        metadata: expect.objectContaining({
+          horizonNetwork: "mainnet",
+          sorobanNetwork: "testnet",
+        }),
+      })
+    );
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,6 +14,6 @@ export default defineConfig({
   },
   test: {
     environment: "node",
-    include: ["src/**/*.test.ts"],
+    include: ["src/**/*.test.ts", "tests/**/*.test.ts"],
   },
 });


### PR DESCRIPTION
Closes #6

## Problem

Network selection in the dashboard is entirely env-var driven, with no concept of "which Stellar network am I pointed at." Worse, the defaults for the two networks the dashboard talks to don't agree:

- `NEXT_PUBLIC_HORIZON_URL` defaults to `https://horizon.stellar.org` — **mainnet**
- `SOROBAN_RPC_URL` defaults to `https://soroban-testnet.stellar.org` — **testnet**

There is no validation and no maintainer-visible indicator if these drift apart. A maintainer could end up validating contributor funding (Horizon) against one network while reading Soroban registry events from a completely different one, with zero warning. "Invalid env configuration" is explicitly called out as an edge case for this issue, and this is a concrete, currently-live instance of it.

## What changed

- **`src/lib/network-config.ts`** — pure classifier module. `classifyHorizonNetwork()` / `classifySorobanNetwork()` map a URL to `"mainnet" | "testnet" | "custom"` by hostname. `getNetworkConfig()` resolves the same URLs/defaults `getHorizonServer()` and `getSorobanRpcUrl()` already use, and flags `mismatched: true` only when both sides resolve to two different *known* named networks — a custom/self-hosted RPC endpoint on either side is intentionally never treated as a false positive, since it can't be confidently classified.
- **`GET /api/settings/network`** — new maintainer-only route (existing `/api/stats` is public, so network detail is kept behind the same `requireMaintainerSession()` guard used by `/api/audit` and `/api/soroban/events`). Returns the resolved config and, on a mismatch, writes a `network_config_mismatch_detected` entry to the existing `AuditLog` table via `recordAuditLog()` — durable, non-blocking, visible later through `GET /api/audit`.
- **`NetworkStatusPanel`** — new component on `/dashboard`, mirrors `TrustlineGuidancePanel`'s card structure. Shows Horizon/Soroban network badges and a warning banner when mismatched.
- **Docs** — `docs/ENVIRONMENT.md`, `docs/ARCHITECTURE.md` (new "Network hardening" section), `README.md`, and `.env.example` all now call out that the two URLs should agree and that a mismatch is surfaced in-app + audited.
- No schema changes — the existing `AuditLog` model already covers what's needed here.

## Pre-existing issues fixed to get a clean baseline

While getting `lint`/`tsc`/`build` green I found a few unrelated pre-existing breaks on `main` (confirmed via `git stash` against an unmodified checkout) and fixed them since a red baseline blocks CI regardless:

- `POST /api/contributors` was missing its CSRF `assertSameOrigin` check entirely (had no `request` param), and `POST /api/register` called `assertSameOrigin` without importing it — despite the README claiming both routes are CSRF-protected.
- `src/app/dashboard/page.tsx` referenced an undefined `recheckOneMutation` (the per-row re-check button was dead code before this PR).
- Two test files (`action-lookup.test.ts`, `batch-verify.test.ts`) had type errors from stale fixtures/inferred parameter types.
- `vitest.config.ts`'s `include` was `src/**/*.test.ts` only, silently excluding the entire `tests/api/**` suite from `npm test`.

## Manual verification

- Default env (no `NEXT_PUBLIC_HORIZON_URL`/`SOROBAN_RPC_URL` set) → `GET /api/settings/network` returns `mismatched: true` (mainnet vs testnet) and the dashboard panel shows the warning banner; an audit entry is written.
- Both URLs pointed at testnet (`horizon-testnet.stellar.org` + `soroban-testnet.stellar.org`) → `mismatched: false`, no banner, no audit entry.
- Non-maintainer session → `403 Forbidden` from `/api/settings/network`.

## Test evidence

`npm run lint`
```
✔ No ESLint warnings or errors
```

`npm test`
```
 Test Files  13 passed (13)
      Tests  77 passed (77)
```

`npx tsc --noEmit` — no output, exit 0.

`npm run build` (with `DATABASE_URL`, `NEXTAUTH_SECRET`, `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET` set as in CI)
```
Compiled successfully
Linting and checking validity of types ...
Collecting page data ...
Generating static pages (8/8)
Finalizing page optimization ...

Route (app)
/api/settings/network   0 B   0 B   (new maintainer-only route, registered correctly)
```
