### PR TITLE
fix(dashboard-041): restore horizon.ts after bad merge

### DIFF
--- a/src/app/dashboard/error.tsx
+++ b/src/app/dashboard/error.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { ErrorFallback } from "@/components/ErrorFallback";
+
+export default function DashboardError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <ErrorFallback
+      error={error}
+      reset={reset}
+      title="Failed to load the maintainer dashboard"
+    />
+  );
+}

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { ErrorFallback } from "@/components/ErrorFallback";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <ErrorFallback error={error} reset={reset} title="Something went wrong" />
+  );
+}

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { classifyError, globalErrorLogger } from "@/lib/error-handling";
+
+import "./globals.css";
+
+/**
+ * Root-level error boundary. Catches errors thrown by the root layout
+ * itself, which `error.tsx` boundaries in nested segments cannot — Next.js
+ * requires this file to render its own `<html>`/`<body>` since it replaces
+ * the root layout when it activates.
+ */
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  const classification = classifyError(error);
+
+  useEffect(() => {
+    globalErrorLogger.log(error, "root-layout");
+  }, [error]);
+
+  return (
+    <html lang="en">
+      <body className="flex min-h-screen items-center justify-center bg-background font-sans text-foreground">
+        <div className="mx-auto max-w-md px-6 py-20 text-center">
+          <h1 className="text-2xl font-semibold">Something went wrong</h1>
+          <p className="mt-2 text-muted-foreground">
+            {classification.message}
+          </p>
+          <button
+            type="button"
+            onClick={reset}
+            className="mt-6 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+          >
+            Try again
+          </button>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/src/app/register/error.tsx
+++ b/src/app/register/error.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { ErrorFallback } from "@/components/ErrorFallback";
+
+export default function RegisterError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <ErrorFallback
+      error={error}
+      reset={reset}
+      title="Failed to load registration"
+    />
+  );
+}

--- a/src/components/ErrorFallback.tsx
+++ b/src/components/ErrorFallback.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useEffect } from "react";
+import { AlertTriangle } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { classifyError, globalErrorLogger } from "@/lib/error-handling";
+
+interface ErrorFallbackProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+  title?: string;
+}
+
+/** Shared UI for App Router error boundaries (`error.tsx` files). */
+export function ErrorFallback({
+  error,
+  reset,
+  title = "Something went wrong",
+}: ErrorFallbackProps) {
+  const classification = classifyError(error);
+
+  useEffect(() => {
+    globalErrorLogger.log(error, title);
+  }, [error, title]);
+
+  return (
+    <div className="mx-auto flex max-w-2xl flex-col items-center px-4 py-20 text-center sm:px-6">
+      <Card className="w-full border-destructive/30 bg-destructive/5">
+        <CardHeader>
+          <div className="mx-auto mb-2 flex h-10 w-10 items-center justify-center rounded-full bg-destructive/10">
+            <AlertTriangle className="h-5 w-5 text-destructive" />
+          </div>
+          <CardTitle>{title}</CardTitle>
+          <CardDescription>{classification.message}</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Button variant="stellar" onClick={reset}>
+            Try again
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/lib/horizon.ts
+++ b/src/lib/horizon.ts
@@ -55,6 +55,8 @@ async function loadAccountFromHorizon(
 ): Promise<Horizon.ServerApi.AccountRecord> {
   const server = getHorizonServer();
   return server.loadAccount(address);
+}
+
 /** True when the balance line is a trustline for the requested asset. */
 function isMatchingTrustline(
   balance: AccountBalance,
@@ -113,39 +115,21 @@ export async function checkStellarAddress(
     ]);
   }
 
-  const errors: string[] = [];
-
-  try {
-    const account = await horizonCircuitBreaker.call(() =>
-      loadAccountFromHorizon(trimmed)
-    );
-    const xlmBalance =
-      account.balances.find((b) => b.asset_type === "native")?.balance ?? "0";
-
-    const trustline = account.balances.some((balance) => {
-      if (balance.asset_type === "native") return false;
-      if (balance.asset_type === "liquidity_pool_shares") return false;
-      return (
-        "asset_code" in balance &&
-        balance.asset_code === assetCode &&
-        "asset_issuer" in balance &&
-        balance.asset_issuer === assetIssuer
-      );
   const cacheKey = buildCacheKey("horizon", trimmed, assetCode, assetIssuer);
   if (useCache) {
     const cached = verificationCache.get(cacheKey) as HorizonCheckResult | null;
     if (cached) return cached;
   }
 
-  const server = getHorizonServer();
-
   try {
-    const account = await withRetry(() => server.loadAccount(trimmed), {
-      attempts: retries,
-      // A missing account (404) will never succeed — fail fast instead of retrying.
-      shouldRetry: (error) =>
-        !isAccountNotFoundError(getHorizonErrorMessage(error)),
-    });
+    const account = await horizonCircuitBreaker.call(() =>
+      withRetry(() => loadAccountFromHorizon(trimmed), {
+        attempts: retries,
+        // A missing account (404) will never succeed — fail fast instead of retrying.
+        shouldRetry: (error) =>
+          !isAccountNotFoundError(getHorizonErrorMessage(error)),
+      })
+    );
 
     const nativeBalance = account.balances.find(
       (b) => b.asset_type === "native"


### PR DESCRIPTION
## Summary
- **Bugfix:** `src/lib/horizon.ts` didn't compile. A prior merge (`d206af5`) left `loadAccountFromHorizon` unclosed and spliced a dead, half-finished duplicate of `checkStellarAddress`'s account-check logic into the middle of the function. Closed the function properly and removed the duplicate block, routing the single remaining Horizon call through the circuit breaker *and* `withRetry` together so checks are cached, retried, and breaker-protected as the file's exports already assumed.
- **Feature (the actual issue ask):** `src/app` had no `error.tsx`/`global-error.tsx` anywhere, so any error thrown below a page fell straight through to Next's generic error screen with no recovery and nothing logged. Added:
  - `src/components/ErrorFallback.tsx` — shared fallback UI, wired to the previously-unused `classifyError`/`globalErrorLogger` in `src/lib/error-handling.ts`.
  - `src/app/error.tsx`, `src/app/register/error.tsx`, `src/app/dashboard/error.tsx` — route-segment boundaries (the dashboard one also covers `/dashboard/settings`, since nested segments inherit their nearest ancestor boundary).
  - `src/app/global-error.tsx` — catches failures in the root layout itself, per Next's requirement that this file render its own `<html>`/`<body>`.
  - Each boundary classifies the error, logs it, shows a friendly message, and offers "Try again" via Next's `reset()`.

## Test plan
No automated tests run (out of scope for this change per task instructions). Manually verified the error boundary files match Next.js App Router conventions (client components, correct `error`/`reset` props, `global-error.tsx` rendering its own document shell).

Closes #41