### PR TITLE
fix(dashboard-040): guide unauthorized trustlines in setup wizard

### DIFF
--- a/src/lib/action-lookup.test.ts
+++ b/src/lib/action-lookup.test.ts
@@ -23,25 +23,56 @@ function result(overrides: Partial<HorizonCheckResult>): HorizonCheckResult {
 describe("computeNextAction", () => {
   it("tells an unfunded account to fund itself (success path)", () => {
     expect(
-      computeNextAction({ funded: false, trustline: false, readiness: "not_ready" })
+      computeNextAction({
+        funded: false,
+        trustline: false,
+        trustline_authorized: false,
+        readiness: "not_ready",
+      })
     ).toBe("fund_account");
   });
 
   it("tells a funded account without a trustline to add one", () => {
     expect(
-      computeNextAction({ funded: true, trustline: false, readiness: "not_ready" })
+      computeNextAction({
+        funded: true,
+        trustline: false,
+        trustline_authorized: false,
+        readiness: "not_ready",
+      })
     ).toBe("add_trustline");
+  });
+
+  it("tells a funded account with an unauthorized trustline to wait on the issuer", () => {
+    expect(
+      computeNextAction({
+        funded: true,
+        trustline: true,
+        trustline_authorized: false,
+        readiness: "not_ready",
+      })
+    ).toBe("await_trustline_authorization");
   });
 
   it("tells a low-reserve account to top up XLM", () => {
     expect(
-      computeNextAction({ funded: true, trustline: true, readiness: "low_reserve" })
+      computeNextAction({
+        funded: true,
+        trustline: true,
+        trustline_authorized: true,
+        readiness: "low_reserve",
+      })
     ).toBe("increase_reserve");
   });
 
   it("reports no action needed once ready", () => {
     expect(
-      computeNextAction({ funded: true, trustline: true, readiness: "ready" })
+      computeNextAction({
+        funded: true,
+        trustline: true,
+        trustline_authorized: true,
+        readiness: "ready",
+      })
     ).toBe("none");
   });
 });
@@ -62,6 +93,7 @@ describe("buildActionLookupResult", () => {
     const horizonResult = result({
       funded: true,
       trustline: true,
+      trustline_authorized: true,
       xlm_balance: "5",
       readiness: "ready",
     });

--- a/src/lib/action-lookup.ts
+++ b/src/lib/action-lookup.ts
@@ -5,6 +5,7 @@ import type { HorizonCheckResult } from "@/types";
 export type WizardAction =
   | "fund_account"
   | "add_trustline"
+  | "await_trustline_authorization"
   | "increase_reserve"
   | "none";
 
@@ -17,16 +18,22 @@ export const WIZARD_ACTION_COPY: Record<WizardAction, string> = {
     "Fund your Stellar account with at least 1 XLM to create it on-network.",
   add_trustline:
     "Add a USDC trustline — your account can't receive Wave payouts without it.",
+  await_trustline_authorization:
+    "Your USDC trustline is present but not yet authorized by the issuer. Wait for authorization or contact the issuer before submitting.",
   increase_reserve:
     "Add more XLM. Your balance is below the configured minimum reserve.",
   none: "You're ready for Wave payouts.",
 };
 
 export function computeNextAction(
-  result: Pick<HorizonCheckResult, "funded" | "trustline" | "readiness">
+  result: Pick<
+    HorizonCheckResult,
+    "funded" | "trustline" | "trustline_authorized" | "readiness"
+  >
 ): WizardAction {
   if (!result.funded) return "fund_account";
   if (!result.trustline) return "add_trustline";
+  if (!result.trustline_authorized) return "await_trustline_authorization";
   if (result.readiness === "low_reserve") return "increase_reserve";
   return "none";
 }


### PR DESCRIPTION
## Summary
- `computeNextAction` (the guidance engine behind the trustline setup wizard shown in `AddressInput.tsx`/`RegisterClient.tsx`) only branched on `funded`, `trustline`, and `readiness === "low_reserve"`.
- A trustline that exists but is not yet authorized by the issuer produces `readiness: "not_ready"` (per `computeReadiness`), which isn't the `"low_reserve"` case — so it fell through to the default `"none"` branch, telling contributors "You're ready for Wave payouts" when their trustline actually can't receive the asset yet.
- Added an explicit `await_trustline_authorization` wizard action + copy, and check `trustline_authorized` before the reserve check so the wizard's guidance matches the real on-chain state end to end.

## Test plan
No automated tests run (out of scope for this change per task instructions). Updated `action-lookup.test.ts` call sites/added a case so the file stays consistent with the tightened `computeNextAction` signature.

Closes #40