### PR TITLE
fix(dashboard-037): remove duplicate onExport prop on maintainer dashboard

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -155,9 +155,6 @@ export default function DashboardPage() {
       ) : (
         <ContributorTable
           contributors={contributors}
-          onExport={() => {
-            exportContributorsCsv(contributors);
-          }}
           onExport={() => exportContributorsCsv(contributors)}
           onRecheck={(id) => recheckOneMutation.mutate(id)}
           recheckingId={

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { Loader2 } from "lucide-react";
+
+import { NetworkStatusPanel } from "@/components/NetworkStatusPanel";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { describeAuditAction } from "@/lib/audit-format";
+import { formatRelativeTime } from "@/lib/utils";
+import type { AuditLogEntry, NetworkConfig } from "@/types";
+
+interface AuditLogResponse {
+  entries: AuditLogEntry[];
+  summary: { total: number; byAction: Record<string, number> };
+}
+
+export default function MaintainerSettingsPage() {
+  const networkQuery = useQuery({
+    queryKey: ["network-config"],
+    queryFn: async () => {
+      const response = await fetch("/api/settings/network");
+      if (!response.ok) throw new Error("Failed to load network config");
+      return (await response.json()) as NetworkConfig;
+    },
+  });
+
+  const auditQuery = useQuery({
+    queryKey: ["audit-log"],
+    queryFn: async () => {
+      const response = await fetch("/api/audit?limit=25");
+      if (!response.ok) throw new Error("Failed to load audit log");
+      return (await response.json()) as AuditLogResponse;
+    },
+  });
+
+  return (
+    <div className="mx-auto max-w-6xl px-4 py-10 sm:px-6">
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold">Maintainer settings</h1>
+        <p className="mt-2 text-muted-foreground">
+          Network configuration and recent maintainer activity for this
+          TrustBridge deployment.
+        </p>
+      </div>
+
+      <div className="mb-8">
+        {networkQuery.isLoading ? (
+          <div className="flex items-center justify-center py-10 text-muted-foreground">
+            <Loader2 className="mr-2 h-5 w-5 animate-spin" />
+            Loading network configuration...
+          </div>
+        ) : networkQuery.isError ? (
+          <p className="text-destructive">
+            Failed to load network configuration.
+          </p>
+        ) : networkQuery.data ? (
+          <NetworkStatusPanel config={networkQuery.data} />
+        ) : null}
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Recent activity</CardTitle>
+          <CardDescription>
+            Rechecks, registrations, and configuration events recorded for
+            this deployment, newest first.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {auditQuery.isLoading ? (
+            <div className="flex items-center justify-center py-10 text-muted-foreground">
+              <Loader2 className="mr-2 h-5 w-5 animate-spin" />
+              Loading activity...
+            </div>
+          ) : auditQuery.isError ? (
+            <p className="text-destructive">Failed to load audit log.</p>
+          ) : !auditQuery.data || auditQuery.data.entries.length === 0 ? (
+            <p className="text-muted-foreground">No activity recorded yet.</p>
+          ) : (
+            <ul className="divide-y divide-border">
+              {auditQuery.data.entries.map((entry) => (
+                <li
+                  key={entry.id}
+                  className="flex flex-wrap items-center justify-between gap-2 py-3 text-sm"
+                >
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Badge variant="secondary">
+                      {describeAuditAction(entry.action)}
+                    </Badge>
+                    {entry.targetLabel && (
+                      <span className="font-mono text-xs text-muted-foreground">
+                        {entry.targetLabel}
+                      </span>
+                    )}
+                    {entry.actorLogin && (
+                      <span className="text-muted-foreground">
+                        by @{entry.actorLogin}
+                      </span>
+                    )}
+                  </div>
+                  <span className="text-muted-foreground">
+                    {formatRelativeTime(entry.createdAt)}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { signIn, signOut, useSession } from "next-auth/react";
-import { LayoutDashboard, Moon, Sun, UserPlus } from "lucide-react";
+import { LayoutDashboard, Moon, Settings, Sun, UserPlus } from "lucide-react";
 import { useTheme } from "next-themes";
 
 import { GitHubIcon } from "@/components/icons/GitHubIcon";
@@ -57,6 +57,14 @@ export function Header() {
               className="text-muted-foreground transition-colors hover:text-foreground"
             >
               Dashboard
+            </Link>
+          )}
+          {session?.user?.isMaintainer && (
+            <Link
+              href="/dashboard/settings"
+              className="text-muted-foreground transition-colors hover:text-foreground"
+            >
+              Settings
             </Link>
           )}
         </nav>
@@ -117,6 +125,19 @@ export function Header() {
               <Link href="/dashboard">
                 <LayoutDashboard className="h-4 w-4" />
                 Dashboard
+              </Link>
+            </Button>
+          )}
+          {session?.user?.isMaintainer && (
+            <Button
+              asChild
+              variant="outline"
+              size="sm"
+              className="hidden sm:inline-flex"
+            >
+              <Link href="/dashboard/settings">
+                <Settings className="h-4 w-4" />
+                Settings
               </Link>
             </Button>
           )}


### PR DESCRIPTION
## Summary
- **Bugfix:** the maintainer dashboard passed `onExport` to `ContributorTable` twice (a wrapped inline callback immediately followed by a duplicate one-liner) — leftover duplication from a bad merge. Removed the redundant duplicate.
- **Feature (the actual issue ask):** there was no maintainer settings *page* — only a read-only `NetworkStatusPanel` embedded in the main dashboard and a maintainer-gated `GET /api/audit` endpoint with no UI consuming it. Added:
  - `src/app/dashboard/settings/page.tsx` — new page reusing `NetworkStatusPanel` for network config and rendering recent audit log activity (via the existing `describeAuditAction`/`formatRelativeTime` helpers).
  - The route is already protected by the existing `/dashboard/:path*` auth middleware and hits already maintainer-gated APIs (`/api/settings/network`, `/api/audit`), so no new auth wiring was needed.
  - Linked from `Header.tsx` for maintainers, next to the existing Dashboard link (both the center nav and the right-side button group).

## Test plan
No automated tests run (out of scope for this change per task instructions). Reviewed `network-config.ts` and `api-auth.ts`, which back the settings panel, and confirmed they're already correct.

Closes #37