### PR TITLE
fix(dashboard-036): harden readiness diff after recheck

### DIFF
--- a/src/app/api/contributors/[id]/route.ts
+++ b/src/app/api/contributors/[id]/route.ts
@@ -29,13 +29,15 @@ export async function POST(_request: Request, { params }: RouteContext) {
     );
   }
 
-  const contributor = await refreshContributor(id);
-  if (!contributor) {
+  const result = await refreshContributor(id);
+  if (!result) {
     return NextResponse.json(
       { error: "Contributor not found" },
       { status: 404 }
     );
   }
+
+  const { contributor, diff } = result;
 
   await recordAuditLog({
     action: "recheck.single",
@@ -43,7 +45,12 @@ export async function POST(_request: Request, { params }: RouteContext) {
     actorLogin: session.user.githubUsername ?? null,
     targetId: contributor.id,
     targetLabel: contributor.githubUsername,
-    metadata: { readiness: contributor.readiness, verified: contributor.verified },
+    metadata: {
+      previousReadiness: diff.previousReadiness,
+      readiness: contributor.readiness,
+      changed: diff.changed,
+      verified: contributor.verified,
+    },
   });
 
   return NextResponse.json({ contributor });

--- a/src/app/api/contributors/route.ts
+++ b/src/app/api/contributors/route.ts
@@ -26,15 +26,19 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
-  const count = await refreshAllContributors();
+  const { refreshed, changed, diffs } = await refreshAllContributors();
   const contributors = await getContributors();
 
   await recordAuditLog({
     action: "recheck.batch",
     actorId: session.user.id,
     actorLogin: session.user.githubUsername ?? null,
-    metadata: { refreshed: count },
+    metadata: {
+      refreshed,
+      changed,
+      diffs: diffs.filter((diff) => diff.changed),
+    },
   });
 
-  return NextResponse.json({ refreshed: count, contributors });
+  return NextResponse.json({ refreshed, contributors });
 }

--- a/src/lib/registrations.ts
+++ b/src/lib/registrations.ts
@@ -5,11 +5,19 @@ import type { Registration } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 import { computeReadiness, computeVerified } from "@/lib/readiness";
 import { buildDashboardStats } from "@/lib/stats";
-import type { ContributorRow, DashboardStats } from "@/types";
+import type { ContributorRow, DashboardStats, ReadinessStatus } from "@/types";
 
 type RegistrationWithUser = Registration & {
   user: { githubUsername: string };
 };
+
+/** Readiness for any persisted registration row (with or without its user join). */
+function readinessOf(row: Registration): ReadinessStatus {
+  return computeReadiness(row.funded, row.trustlineReady, row.xlmBalance, {
+    authorized: row.trustlineAuthorized,
+    spendableBalance: row.spendableXlmBalance,
+  });
+}
 
 /** Map a persisted registration (+ user) to a serializable contributor row. */
 export function toContributorRow(row: RegistrationWithUser): ContributorRow {
@@ -28,10 +36,7 @@ export function toContributorRow(row: RegistrationWithUser): ContributorRow {
     xlmBalance: row.xlmBalance,
     spendableXlmBalance: row.spendableXlmBalance,
     lastCheckedAt: row.lastCheckedAt?.toISOString() ?? null,
-    readiness: computeReadiness(row.funded, row.trustlineReady, row.xlmBalance, {
-      authorized: row.trustlineAuthorized,
-      spendableBalance: row.spendableXlmBalance,
-    }),
+    readiness: readinessOf(row),
   };
 }
 
@@ -71,17 +76,33 @@ export async function getContributors(): Promise<ContributorRow[]> {
   return registrations.map(toContributorRow);
 }
 
+export interface ReadinessDiff {
+  registrationId: string;
+  previousReadiness: ReadinessStatus;
+  newReadiness: ReadinessStatus;
+  changed: boolean;
+}
+
+interface RecheckOutcome {
+  registration: Registration;
+  diff: ReadinessDiff;
+}
+
 /**
  * Re-run the Horizon check for a single registration and persist the result.
- * Shared by the single- and batch-recheck flows.
+ * Shared by the single- and batch-recheck flows. Captures the readiness
+ * before and after the check so callers can audit what actually changed,
+ * rather than just the post-recheck state.
  */
 async function recheckRegistration(
   registration: Registration
-): Promise<Registration> {
+): Promise<RecheckOutcome> {
+  const previousReadiness = readinessOf(registration);
+
   const { checkStellarAddress } = await import("@/lib/horizon");
   const result = await checkStellarAddress(registration.stellarAddress);
 
-  return prisma.registration.update({
+  const updated = await prisma.registration.update({
     where: { id: registration.id },
     data: {
       funded: result.funded,
@@ -92,34 +113,64 @@ async function recheckRegistration(
       lastCheckedAt: new Date(),
     },
   });
+
+  const newReadiness = readinessOf(updated);
+
+  return {
+    registration: updated,
+    diff: {
+      registrationId: updated.id,
+      previousReadiness,
+      newReadiness,
+      changed: previousReadiness !== newReadiness,
+    },
+  };
 }
 
-export async function refreshAllContributors(): Promise<number> {
+export interface RefreshAllSummary {
+  refreshed: number;
+  changed: number;
+  diffs: ReadinessDiff[];
+}
+
+export async function refreshAllContributors(): Promise<RefreshAllSummary> {
   const registrations = await prisma.registration.findMany();
 
-  await Promise.all(
+  const outcomes = await Promise.all(
     registrations.map((registration) => recheckRegistration(registration))
   );
 
-  return registrations.length;
+  const diffs = outcomes.map((outcome) => outcome.diff);
+
+  return {
+    refreshed: registrations.length,
+    changed: diffs.filter((diff) => diff.changed).length,
+    diffs,
+  };
+}
+
+export interface RefreshContributorResult {
+  contributor: ContributorRow;
+  diff: ReadinessDiff;
 }
 
 /**
  * Re-check a single contributor by registration id. Returns the refreshed
- * contributor row, or `null` when no registration matches.
+ * contributor row plus the before/after readiness diff, or `null` when no
+ * registration matches.
  */
 export async function refreshContributor(
   id: string
-): Promise<ContributorRow | null> {
+): Promise<RefreshContributorResult | null> {
   const registration = await prisma.registration.findUnique({ where: { id } });
   if (!registration) return null;
 
-  await recheckRegistration(registration);
+  const { diff } = await recheckRegistration(registration);
 
   const updated = await prisma.registration.findUnique({
     where: { id },
     include: { user: { select: { githubUsername: true } } },
   });
 
-  return updated ? toContributorRow(updated) : null;
+  return updated ? { contributor: toContributorRow(updated), diff } : null;
 }

--- a/tests/api/contributors.test.ts
+++ b/tests/api/contributors.test.ts
@@ -56,7 +56,11 @@ describe("POST /api/contributors", () => {
     vi.mocked(getServerSession).mockResolvedValue({
       user: { id: "user-1", isMaintainer: true },
     } as any);
-    vi.mocked(refreshAllContributors).mockResolvedValue(3);
+    vi.mocked(refreshAllContributors).mockResolvedValue({
+      refreshed: 3,
+      changed: 0,
+      diffs: [],
+    });
     vi.mocked(getContributors).mockResolvedValue([] as any);
 
     const r = post();


### PR DESCRIPTION
## Summary
- Recheck audit entries only ever recorded the *post-recheck* state:
  - `recheck.single` logged `{ readiness, verified }` with nothing to compare against.
  - `recheck.batch` logged only `{ refreshed: count }` — no indication of which contributors' readiness actually changed, or how.
- Maintainers had no durable record of what a recheck actually changed, which matters most during active Waves when a recheck can flip a contributor from `ready` to `not_ready` (or vice versa) right before payout.
- `recheckRegistration` (shared by both recheck flows in `src/lib/registrations.ts`) now captures readiness before and after the Horizon check and returns a `ReadinessDiff`. `refreshContributor` and `refreshAllContributors` surface it so both API routes (`/api/contributors`, `/api/contributors/[id]`) log `previousReadiness`/`newReadiness` (and, for the batch route, only the diffs that actually changed) instead of just final state.
- No schema change needed — `AuditLog.metadata` is already a flexible JSON column.
- Public response shapes are unchanged (`{ contributor }`, `{ refreshed, contributors }`), so the dashboard UI needs no changes.

## Test plan
No automated tests run (out of scope for this change per task instructions). Updated `tests/api/contributors.test.ts`'s mock of `refreshAllContributors` to match its new return shape so the file stays consistent with the signature change.

Closes #36