### PR TITLE
feat: resolve Wave issues #34 #45 #48 #49

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ All docs are cross-linked from this README:
 | [**Deployment**](./docs/DEPLOYMENT.md) | Vercel deployment checklist |
 | [**Contributing**](./docs/CONTRIBUTING.md) | How to contribute to this repo |
 | [**CSRF protection**](./docs/CSRF.md) | Threat model, protected routes, non-browser client policy, testing guide |
+| [**Sentry error tracking**](./docs/SENTRY.md) | Setup, environment variables, instrumented routes, testing guide |
 
 ---
 
@@ -160,6 +161,7 @@ All docs are cross-linked from this README:
 | `/api/actions/lookup` | GET | Cached Horizon readiness lookup + wizard `nextAction` guidance, `?address=G...` |
 | `/api/soroban/events` | GET | Recent events for `SOROBAN_CONTRACT_ID` (maintainer only) |
 | `/api/settings/network` | GET | Resolved Horizon/Soroban network + mismatch warnings (maintainer only) |
+| `/api/health` | GET | Liveness + readiness probe — DB ping and CSV staleness check (public, always 200) |
 
 ### Resilience
 

--- a/docs/SENTRY.md
+++ b/docs/SENTRY.md
@@ -1,0 +1,292 @@
+# Sentry Error Tracking
+
+TrustBridge Dashboard integrates Sentry for runtime error monitoring across the
+Next.js API layer and server components. The integration is **opt-in**: the
+application functions correctly without Sentry configured — every helper
+degrades to a silent no-op — so local development and CI never require a DSN.
+
+---
+
+## Table of contents
+
+- [How it works](#how-it-works)
+- [Setup](#setup)
+- [Environment variables](#environment-variables)
+- [Using the helpers](#using-the-helpers)
+- [Instrumented routes](#instrumented-routes)
+- [Source maps (optional)](#source-maps-optional)
+- [Testing](#testing)
+- [FAQ](#faq)
+
+---
+
+## How it works
+
+All Sentry calls are centralised in **`src/lib/sentry.ts`**. Application code
+always imports from there, never directly from `@sentry/nextjs`, so the SDK
+surface area is contained to a single file.
+
+At startup `src/lib/sentry.ts` checks for `NEXT_PUBLIC_SENTRY_DSN`:
+
+| DSN present | `@sentry/nextjs` installed | Behaviour |
+|-------------|----------------------------|-----------|
+| ✅           | ✅                          | Real Sentry events sent |
+| ✅           | ❌                          | Graceful no-op (install the SDK) |
+| ❌           | —                           | Silent no-op (development / CI) |
+
+---
+
+## Setup
+
+### 1. Install the SDK
+
+```bash
+npm install @sentry/nextjs
+```
+
+### 2. Create Sentry project config files
+
+Run the Sentry wizard (recommended) or create the files manually:
+
+```bash
+npx @sentry/wizard@latest -i nextjs
+```
+
+The wizard creates:
+- `sentry.client.config.ts` — browser-side initialisation
+- `sentry.server.config.ts` — Node.js server initialisation
+- `sentry.edge.config.ts` — Edge runtime initialisation
+
+Minimal `sentry.server.config.ts`:
+
+```ts
+import * as Sentry from "@sentry/nextjs";
+
+Sentry.init({
+  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+  environment: process.env.NEXT_PUBLIC_APP_ENV ?? "development",
+  tracesSampleRate: 0.1,
+  // Mask PII before events leave the server
+  beforeSend(event) {
+    // Strip access tokens / stellar addresses from breadcrumbs if needed
+    return event;
+  },
+});
+```
+
+### 3. Configure `next.config.mjs`
+
+```js
+import { withSentryConfig } from "@sentry/nextjs";
+
+export default withSentryConfig(nextConfig, {
+  org: "your-sentry-org",
+  project: "trustbridge-dashboard",
+  silent: true,
+  widenClientFileUpload: true,
+  hideSourceMaps: true,
+  disableLogger: true,
+});
+```
+
+### 4. Set environment variables
+
+```bash
+# .env.local
+NEXT_PUBLIC_SENTRY_DSN=https://<key>@<org>.ingest.sentry.io/<project-id>
+SENTRY_AUTH_TOKEN=<token-for-source-map-uploads>   # CI only
+```
+
+---
+
+## Environment variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `NEXT_PUBLIC_SENTRY_DSN` | Optional | Sentry DSN. No-op when absent. |
+| `SENTRY_AUTH_TOKEN` | CI/CD only | Token for uploading source maps during build. |
+| `NEXT_PUBLIC_APP_ENV` | Optional | Sets the Sentry `environment` tag (`production`, `staging`, etc.). Defaults to `"development"`. |
+
+---
+
+## Using the helpers
+
+Import from `@/lib/sentry` in server-side code:
+
+```ts
+import {
+  captureException,
+  captureMessage,
+  captureExceptionWithScope,
+  setSentryUser,
+  flushSentry,
+  isSentryEnabled,
+} from "@/lib/sentry";
+```
+
+### `captureException(error, context?)`
+
+Report an unhandled exception. Preferred for `catch` blocks:
+
+```ts
+try {
+  await riskyOperation();
+} catch (err) {
+  captureException(err, { route: "/api/contributors", userId: session.user.id });
+  return NextResponse.json({ error: "Internal error" }, { status: 500 });
+}
+```
+
+### `captureMessage(message, level?)`
+
+Send an informational message (not an exception):
+
+```ts
+captureMessage("CSV export requested with stale data", "warning");
+```
+
+Level defaults to `"info"`. Valid values: `"debug" | "info" | "warning" | "error" | "fatal"`.
+
+### `captureExceptionWithScope(error, user, tags, level?)`
+
+Capture with rich metadata without polluting other concurrent events:
+
+```ts
+captureExceptionWithScope(
+  err,
+  { id: session.user.id, username: session.user.githubUsername },
+  { route: "/api/register", network: "mainnet" },
+  "error"
+);
+```
+
+### `setSentryUser(user | null)`
+
+Attach user identity to all subsequent events in the current scope. Call on
+sign-in; pass `null` on sign-out:
+
+```ts
+// In NextAuth callbacks:
+setSentryUser({ id: userId, username: githubUsername });
+```
+
+### `flushSentry(timeoutMs?)`
+
+Ensure pending events are sent before a serverless function terminates. Default
+timeout is 2 seconds:
+
+```ts
+// At the end of a background task:
+await flushSentry(2000);
+```
+
+### `isSentryEnabled()`
+
+Conditional logging helper — avoids noise in development:
+
+```ts
+if (isSentryEnabled()) {
+  console.info("Sentry event sent:", eventId);
+}
+```
+
+---
+
+## Instrumented routes
+
+The following routes are recommended instrumentation points:
+
+| Route | Instrumented at | Why |
+|-------|----------------|-----|
+| `POST /api/check` | Outer `catch` block | Horizon errors and unexpected exceptions |
+| `POST /api/register` | Outer `catch` block | DB write failures, Horizon errors |
+| `GET /api/contributors` | DB query failures | Prisma connection errors |
+| `POST /api/contributors` | Batch recheck failures | Partial Horizon batch failures |
+| `POST /api/contributors/[id]` | Recheck errors | Single-contributor recheck failures |
+| `GET /api/health` | Health check degradations | Stale-data warnings |
+| `GET /api/audit` | Auth failures | Unexpected 403s |
+
+To add instrumentation, wrap the handler body:
+
+```ts
+import { captureException } from "@/lib/sentry";
+
+export async function POST(request: NextRequest) {
+  try {
+    // ... handler logic
+  } catch (err) {
+    captureException(err, { route: "POST /api/register" });
+    return NextResponse.json({ error: "Internal error" }, { status: 500 });
+  }
+}
+```
+
+---
+
+## Source maps (optional)
+
+Source maps let Sentry show original TypeScript line numbers rather than
+minified bundle locations. They are uploaded during the build by
+`@sentry/nextjs` when `SENTRY_AUTH_TOKEN` is set:
+
+```bash
+# In CI (e.g. GitHub Actions / Vercel):
+SENTRY_AUTH_TOKEN=<token> npm run build
+```
+
+Source maps are **never sent to the browser** when `hideSourceMaps: true` is
+set in `next.config.mjs` (the default in the wizard-generated config).
+
+---
+
+## Testing
+
+Unit tests for `src/lib/sentry.ts` live in `tests/unit/sentry.test.ts` and
+cover:
+
+- No-op behaviour when `NEXT_PUBLIC_SENTRY_DSN` is absent
+- Graceful fallback when DSN is set but `@sentry/nextjs` is not installed
+- All public helper functions (`captureException`, `captureMessage`,
+  `captureExceptionWithScope`, `setSentryUser`, `flushSentry`,
+  `isSentryEnabled`)
+- Edge cases (blank DSN, non-Error thrown values, null user, empty tags)
+
+Run the unit suite:
+
+```bash
+npm test
+# or targeted:
+npx vitest run tests/unit/sentry.test.ts
+```
+
+To test that real events reach Sentry in staging, set `NEXT_PUBLIC_SENTRY_DSN`
+to your **test** project DSN and trigger an error:
+
+```bash
+NEXT_PUBLIC_SENTRY_DSN=https://... npm run dev
+# Then hit POST /api/check with an invalid body to trigger a 500
+```
+
+---
+
+## FAQ
+
+**Q: Do I need `@sentry/nextjs` installed for tests to pass?**
+No. The SDK is an optional peer dependency. Tests run against the no-op stub
+when the DSN is absent, which is the default in CI.
+
+**Q: Will Sentry capture PII (Stellar addresses, GitHub usernames)?**
+Only if you pass them explicitly in `context` / `tags`. The default SDK
+configuration scrubs common PII patterns; review Sentry's
+[data scrubbing](https://docs.sentry.io/product/data-management-settings/scrubbing/)
+settings for your project.
+
+**Q: Can I use Sentry on the Edge runtime?**
+Yes. `@sentry/nextjs` supports the Edge runtime via `sentry.edge.config.ts`.
+The helpers in `src/lib/sentry.ts` work in both Node.js and Edge contexts.
+
+**Q: How do I test Sentry in production without spamming events?**
+Use Sentry [environments](https://docs.sentry.io/product/sentry-basics/environments/)
+(`NEXT_PUBLIC_APP_ENV=staging`) and
+[sampling](https://docs.sentry.io/platforms/javascript/configuration/sampling/)
+to control event volume.

--- a/src/app/api/contributors/route.ts
+++ b/src/app/api/contributors/route.ts
@@ -4,17 +4,72 @@ import { requireMaintainerSession } from "@/lib/api-auth";
 import { recordAuditLog } from "@/lib/audit";
 import { assertSameOrigin } from "@/lib/csrf";
 import { getContributors, refreshAllContributors } from "@/lib/registrations";
+import type { ReadinessStatus } from "@/types";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-export async function GET() {
+/**
+ * Valid values for the `?readiness=` query parameter.
+ * Passing `low_reserve` returns only contributors whose spendable XLM balance
+ * is below the configured minimum — a separate category that helps maintainers
+ * triage accounts that would fail a Wave payout for reserve reasons only.
+ */
+const VALID_READINESS_FILTERS = new Set<ReadinessStatus>([
+  "ready",
+  "low_reserve",
+  "not_ready",
+]);
+
+/**
+ * GET /api/contributors[?readiness=<status>]
+ *
+ * Returns the contributor list, optionally filtered to a single readiness tier.
+ *
+ * Query params:
+ *   `readiness` — one of `ready | low_reserve | not_ready`.
+ *                 Omit to return all contributors.
+ *
+ * The `low_reserve` filter is the key addition for issue #34: it lets
+ * maintainers identify accounts that are funded and have an authorized
+ * trustline but don't yet carry enough spendable XLM to cover the minimum
+ * reserve, so they can be addressed before a Wave disbursement.
+ *
+ * Auth: maintainer-only.
+ */
+export async function GET(request: NextRequest) {
   if (!(await requireMaintainerSession())) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
-  const contributors = await getContributors();
-  return NextResponse.json({ contributors });
+  const readinessParam = request.nextUrl.searchParams.get("readiness");
+
+  // Validate the filter if provided
+  if (
+    readinessParam !== null &&
+    !VALID_READINESS_FILTERS.has(readinessParam as ReadinessStatus)
+  ) {
+    return NextResponse.json(
+      {
+        error: `Invalid readiness filter "${readinessParam}". Must be one of: ${Array.from(VALID_READINESS_FILTERS).join(", ")}`,
+      },
+      { status: 400 }
+    );
+  }
+
+  const allContributors = await getContributors();
+
+  const contributors =
+    readinessParam !== null
+      ? allContributors.filter((c) => c.readiness === readinessParam)
+      : allContributors;
+
+  return NextResponse.json({
+    contributors,
+    total: allContributors.length,
+    filtered: contributors.length,
+    ...(readinessParam !== null ? { readiness: readinessParam } : {}),
+  });
 }
 
 export async function POST(request: NextRequest) {

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,136 @@
+import { NextResponse } from "next/server";
+
+import { prisma } from "@/lib/prisma";
+import { buildStalenessSummary } from "@/lib/stale-export";
+import { toContributorRow } from "@/lib/registrations";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export type HealthStatus = "ok" | "degraded" | "error";
+
+export interface HealthResponse {
+  status: HealthStatus;
+  timestamp: string;
+  checks: {
+    database: { status: HealthStatus; latencyMs: number; error?: string };
+    csvStaleness: {
+      status: HealthStatus;
+      staleCount: number;
+      totalCount: number;
+      stalePercent: number;
+      warning: string;
+    };
+  };
+  version: string;
+}
+
+/**
+ * GET /api/health
+ *
+ * Lightweight liveness + readiness probe for the TrustBridge Dashboard.
+ *
+ * Always returns 200 so load-balancer liveness checks never kill the pod on a
+ * degraded-but-alive service. Use the `status` field in the body to
+ * distinguish:
+ *
+ * - `"ok"`       — database reachable, CSV data fresh
+ * - `"degraded"` — database reachable but CSV data is stale (Wave risk)
+ * - `"error"`    — database unreachable (critical)
+ *
+ * The response is intentionally unauthenticated so monitoring tools can poll
+ * it without credentials. **No contributor PII is exposed** — only aggregate
+ * counts and percentages are returned.
+ *
+ * @see docs/SENTRY.md for how Sentry integrates with this endpoint.
+ */
+export async function GET(): Promise<NextResponse<HealthResponse>> {
+  const timestamp = new Date().toISOString();
+  const version = process.env.npm_package_version ?? "0.1.0";
+
+  // ------------------------------------------------------------------
+  // Database check
+  // ------------------------------------------------------------------
+  let dbStatus: HealthStatus = "ok";
+  let dbLatencyMs = 0;
+  let dbError: string | undefined;
+
+  const dbStart = Date.now();
+  try {
+    await prisma.$queryRaw`SELECT 1`;
+    dbLatencyMs = Date.now() - dbStart;
+  } catch (err) {
+    dbLatencyMs = Date.now() - dbStart;
+    dbStatus = "error";
+    dbError = err instanceof Error ? err.message : "Unknown database error";
+  }
+
+  // ------------------------------------------------------------------
+  // CSV staleness check (only when DB is reachable)
+  // ------------------------------------------------------------------
+  let csvStatus: HealthStatus = "ok";
+  let csvSummary = {
+    staleCount: 0,
+    totalCount: 0,
+    stalePercent: 0,
+    warning: "",
+  };
+
+  if (dbStatus !== "error") {
+    try {
+      const registrations = await prisma.registration.findMany({
+        include: { user: { select: { githubUsername: true } } },
+        orderBy: { updatedAt: "desc" },
+      });
+
+      const rows = registrations.map(toContributorRow);
+      const summary = buildStalenessSummary(rows);
+
+      csvSummary = {
+        staleCount: summary.staleCount,
+        totalCount: summary.totalCount,
+        stalePercent: summary.stalePercent,
+        warning: summary.warning,
+      };
+
+      if (summary.stale) {
+        csvStatus = "degraded";
+      }
+    } catch {
+      // Non-fatal: if the staleness query fails we mark degraded but don't
+      // escalate to error (the DB ping above already covers connectivity).
+      csvStatus = "degraded";
+      csvSummary.warning =
+        "Unable to determine CSV staleness. Re-check contributor data before exporting.";
+    }
+  }
+
+  // ------------------------------------------------------------------
+  // Overall status
+  // ------------------------------------------------------------------
+  let overallStatus: HealthStatus = "ok";
+  if (dbStatus === "error") {
+    overallStatus = "error";
+  } else if (csvStatus === "degraded") {
+    overallStatus = "degraded";
+  }
+
+  const body: HealthResponse = {
+    status: overallStatus,
+    timestamp,
+    checks: {
+      database: {
+        status: dbStatus,
+        latencyMs: dbLatencyMs,
+        ...(dbError ? { error: dbError } : {}),
+      },
+      csvStaleness: {
+        status: csvStatus,
+        ...csvSummary,
+      },
+    },
+    version,
+  };
+
+  return NextResponse.json(body, { status: 200 });
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -29,10 +29,6 @@ interface ContributorsResponse {
   contributors: ContributorRow[];
 }
 
-interface ContributorResponse {
-  contributor: ContributorRow;
-}
-
 export default function DashboardPage() {
   const queryClient = useQueryClient();
 
@@ -155,9 +151,6 @@ export default function DashboardPage() {
       ) : (
         <ContributorTable
           contributors={contributors}
-          onExport={() => {
-            exportContributorsCsv(contributors);
-          }}
           onExport={() => exportContributorsCsv(contributors)}
           onRecheck={(id) => recheckOneMutation.mutate(id)}
           recheckingId={

--- a/src/lib/horizon.ts
+++ b/src/lib/horizon.ts
@@ -50,11 +50,6 @@ export function getHorizonCircuitBreakerMetrics(): ReturnType<
   return horizonCircuitBreaker.getMetrics();
 }
 
-async function loadAccountFromHorizon(
-  address: string
-): Promise<Horizon.ServerApi.AccountRecord> {
-  const server = getHorizonServer();
-  return server.loadAccount(address);
 /** True when the balance line is a trustline for the requested asset. */
 function isMatchingTrustline(
   balance: AccountBalance,
@@ -113,24 +108,6 @@ export async function checkStellarAddress(
     ]);
   }
 
-  const errors: string[] = [];
-
-  try {
-    const account = await horizonCircuitBreaker.call(() =>
-      loadAccountFromHorizon(trimmed)
-    );
-    const xlmBalance =
-      account.balances.find((b) => b.asset_type === "native")?.balance ?? "0";
-
-    const trustline = account.balances.some((balance) => {
-      if (balance.asset_type === "native") return false;
-      if (balance.asset_type === "liquidity_pool_shares") return false;
-      return (
-        "asset_code" in balance &&
-        balance.asset_code === assetCode &&
-        "asset_issuer" in balance &&
-        balance.asset_issuer === assetIssuer
-      );
   const cacheKey = buildCacheKey("horizon", trimmed, assetCode, assetIssuer);
   if (useCache) {
     const cached = verificationCache.get(cacheKey) as HorizonCheckResult | null;
@@ -140,12 +117,14 @@ export async function checkStellarAddress(
   const server = getHorizonServer();
 
   try {
-    const account = await withRetry(() => server.loadAccount(trimmed), {
-      attempts: retries,
-      // A missing account (404) will never succeed — fail fast instead of retrying.
-      shouldRetry: (error) =>
-        !isAccountNotFoundError(getHorizonErrorMessage(error)),
-    });
+    const account = await horizonCircuitBreaker.call(() =>
+      withRetry(() => server.loadAccount(trimmed), {
+        attempts: retries,
+        // A missing account (404) will never succeed — fail fast instead of retrying.
+        shouldRetry: (error) =>
+          !isAccountNotFoundError(getHorizonErrorMessage(error)),
+      })
+    );
 
     const nativeBalance = account.balances.find(
       (b) => b.asset_type === "native"

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -1,0 +1,229 @@
+/**
+ * Sentry error tracking integration for TrustBridge Dashboard.
+ *
+ * This module provides a thin wrapper around Sentry so that:
+ *  1. The real `@sentry/nextjs` package can be wired in at deploy time by
+ *     setting `NEXT_PUBLIC_SENTRY_DSN` (and optionally `SENTRY_AUTH_TOKEN`
+ *     for source-map uploads).
+ *  2. Without a DSN the module degrades gracefully — every helper is a no-op —
+ *     so local development and CI tests work without installing the SDK.
+ *  3. Application code always imports from `@/lib/sentry`, never directly from
+ *     `@sentry/nextjs`, keeping the surface area of the Sentry dependency to a
+ *     single file.
+ *
+ * @see docs/SENTRY.md for setup, environment variables, and testing guidance.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface SentryScope {
+  setTag(key: string, value: string): void;
+  setUser(user: { id?: string; username?: string } | null): void;
+  setExtra(key: string, value: unknown): void;
+  setLevel(level: SentryLevel): void;
+}
+
+export type SentryLevel = "debug" | "info" | "warning" | "error" | "fatal";
+
+export interface SentryClient {
+  captureException(error: unknown, context?: Record<string, unknown>): string;
+  captureMessage(message: string, level?: SentryLevel): string;
+  withScope(callback: (scope: SentryScope) => void): void;
+  setUser(user: { id?: string; username?: string } | null): void;
+  flush(timeout?: number): Promise<boolean>;
+}
+
+// ---------------------------------------------------------------------------
+// No-op stub (used when NEXT_PUBLIC_SENTRY_DSN is absent)
+// ---------------------------------------------------------------------------
+
+const noop = (): void => undefined;
+
+const noopScope: SentryScope = {
+  setTag: noop,
+  setUser: noop,
+  setExtra: noop,
+  setLevel: noop,
+};
+
+const noopClient: SentryClient = {
+  captureException: () => "",
+  captureMessage: () => "",
+  withScope: (cb) => cb(noopScope),
+  setUser: noop,
+  flush: async () => true,
+};
+
+// ---------------------------------------------------------------------------
+// Client resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the resolved Sentry client.
+ *
+ * When `NEXT_PUBLIC_SENTRY_DSN` is set the real `@sentry/nextjs` package is
+ * used; otherwise the no-op stub is returned so callers never need to null-
+ * check the result.
+ *
+ * The dynamic `require()` is intentional: it allows the package to be an
+ * optional peer dependency (not listed in `dependencies`) so that teams that
+ * don't want Sentry can simply omit the DSN without an install-time error.
+ */
+function resolveClient(): SentryClient {
+  const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN?.trim();
+  if (!dsn) return noopClient;
+
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const Sentry = require("@sentry/nextjs") as {
+      captureException: (error: unknown, context?: Record<string, unknown>) => string | undefined;
+      captureMessage: (message: string, level?: string) => string | undefined;
+      withScope: (cb: (scope: {
+        setTag(k: string, v: string): void;
+        setUser(u: { id?: string; username?: string } | null): void;
+        setExtra(k: string, v: unknown): void;
+        setLevel(l: string): void;
+      }) => void) => void;
+      setUser: (u: { id?: string; username?: string } | null) => void;
+      flush: (timeout?: number) => Promise<boolean>;
+    };
+    return {
+      captureException: (error, context) => {
+        return Sentry.captureException(error, context) ?? "";
+      },
+      captureMessage: (message, level = "info") => {
+        return Sentry.captureMessage(message, level) ?? "";
+      },
+      withScope: (cb) => {
+        Sentry.withScope((scope) => {
+          cb({
+            setTag: (k, v) => scope.setTag(k, v),
+            setUser: (u) => scope.setUser(u),
+            setExtra: (k, v) => scope.setExtra(k, v),
+            setLevel: (l) => scope.setLevel(l),
+          });
+        });
+      },
+      setUser: (u) => Sentry.setUser(u),
+      flush: (timeout) => Sentry.flush(timeout),
+    };
+  } catch {
+    // @sentry/nextjs is not installed — fall back to no-op.
+    return noopClient;
+  }
+}
+
+// Singleton so the DSN check and require() happen at most once per process.
+let _client: SentryClient | null = null;
+
+function getClient(): SentryClient {
+  if (!_client) _client = resolveClient();
+  return _client;
+}
+
+// Exposed for tests that need to reset the singleton between runs.
+export function _resetSentryClient(): void {
+  _client = null;
+}
+
+// ---------------------------------------------------------------------------
+// Public helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Report an unhandled exception to Sentry.
+ *
+ * @param error   The caught value (ideally an `Error` instance).
+ * @param context Optional key/value pairs attached to the event as "extra"
+ *                data (e.g. `{ route: "/api/contributors", userId: "u_123" }`).
+ * @returns       The Sentry event id, or an empty string when Sentry is
+ *                unconfigured.
+ *
+ * @example
+ * ```ts
+ * try {
+ *   await riskyOperation();
+ * } catch (err) {
+ *   captureException(err, { route: "/api/register" });
+ *   return NextResponse.json({ error: "Internal error" }, { status: 500 });
+ * }
+ * ```
+ */
+export function captureException(
+  error: unknown,
+  context?: Record<string, unknown>
+): string {
+  return getClient().captureException(error, context);
+}
+
+/**
+ * Send an informational message (not an exception) to Sentry.
+ *
+ * @param message Human-readable description of the event.
+ * @param level   Sentry severity level. Defaults to `"info"`.
+ * @returns       The Sentry event id, or an empty string when unconfigured.
+ */
+export function captureMessage(
+  message: string,
+  level: SentryLevel = "info"
+): string {
+  return getClient().captureMessage(message, level);
+}
+
+/**
+ * Capture an exception with additional scope data (tags, user, level).
+ *
+ * Prefer `captureException` for the common case; use this only when you need
+ * to attach extra metadata that shouldn't bleed into other events.
+ *
+ * @example
+ * ```ts
+ * captureExceptionWithScope(err, { id: session.user.id }, { route: "/api/check" }, "error");
+ * ```
+ */
+export function captureExceptionWithScope(
+  error: unknown,
+  user: { id?: string; username?: string } | null,
+  tags: Record<string, string> = {},
+  level: SentryLevel = "error"
+): string {
+  let eventId = "";
+  getClient().withScope((scope) => {
+    scope.setUser(user);
+    scope.setLevel(level);
+    for (const [k, v] of Object.entries(tags)) {
+      scope.setTag(k, v);
+    }
+    eventId = getClient().captureException(error);
+  });
+  return eventId;
+}
+
+/**
+ * Associate a user with subsequent Sentry events for the current hub/scope.
+ * Call this on sign-in; pass `null` to clear on sign-out.
+ */
+export function setSentryUser(
+  user: { id?: string; username?: string } | null
+): void {
+  getClient().setUser(user);
+}
+
+/**
+ * Flush pending Sentry events before a serverless function terminates.
+ * Call this at the end of long-running background tasks or in `onRequestEnd`
+ * middleware hooks.
+ */
+export async function flushSentry(timeoutMs = 2000): Promise<boolean> {
+  return getClient().flush(timeoutMs);
+}
+
+/**
+ * `true` when a real Sentry DSN is configured and events will actually be
+ * sent to sentry.io. Useful for conditional log messages in development.
+ */
+export function isSentryEnabled(): boolean {
+  return Boolean(process.env.NEXT_PUBLIC_SENTRY_DSN?.trim());
+}

--- a/tests/api/check.test.ts
+++ b/tests/api/check.test.ts
@@ -9,12 +9,6 @@ vi.mock("@/lib/horizon", () => ({
 import { checkStellarAddress } from "@/lib/horizon";
 import { resetRateLimit } from "@/lib/rate-limit";
 
-function post(body: unknown) {
-  return new NextRequest("http://localhost:3000/api/check", {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-    },
 const sameOriginHeaders: Record<string, string> = {
   origin: "http://localhost:3000",
   host: "localhost:3000",
@@ -50,9 +44,12 @@ describe("POST /api/check", () => {
     vi.mocked(checkStellarAddress).mockResolvedValue({
       funded: true,
       trustline: true,
-      xlm_balance: 2,
+      trustline_authorized: true,
+      verified: true,
+      xlm_balance: "2",
+      spendable_xlm_balance: "1.5",
       readiness: "ready",
-      horizon_error: null,
+      errors: [],
     } as any);
 
     // Exhaust the default limit (10 requests)
@@ -80,16 +77,12 @@ describe("POST /api/check", () => {
     vi.mocked(checkStellarAddress).mockResolvedValue({
       funded: false,
       trustline: false,
+      trustline_authorized: false,
+      verified: false,
       xlm_balance: "0",
+      spendable_xlm_balance: "0",
       readiness: "not_ready",
       errors: ["Horizon is temporarily unavailable. Please try again later."],
-  it("returns 200 with mocked result (same-origin)", async () => {
-    vi.mocked(checkStellarAddress).mockResolvedValue({
-      funded: true,
-      trustline: true,
-      xlm_balance: 2,
-      readiness: "ready",
-      horizon_error: null,
     } as any);
 
     const r = post({ address: "GBSX" });
@@ -101,12 +94,30 @@ describe("POST /api/check", () => {
     );
   });
 
+  it("returns 200 with mocked result (same-origin)", async () => {
+    vi.mocked(checkStellarAddress).mockResolvedValue({
+      funded: true,
+      trustline: true,
+      trustline_authorized: true,
+      verified: true,
+      xlm_balance: "2",
+      spendable_xlm_balance: "1.5",
+      readiness: "ready",
+      errors: [],
+    } as any);
+
+    const r = post({ address: "GBSX" });
+    const res = await POST(r);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.funded).toBe(true);
+  });
+
   it("returns 500 for unexpected errors", async () => {
     vi.mocked(checkStellarAddress).mockRejectedValue(new Error("boom"));
 
     const r = post({ address: "GBSX" });
     const res = await POST(r);
     expect(res.status).toBe(500);
-    expect(json.funded).toBe(true);
   });
 });

--- a/tests/api/contributors.test.ts
+++ b/tests/api/contributors.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NextRequest } from "next/server";
-import { POST } from "@/app/api/contributors/route";
+import { GET, POST } from "@/app/api/contributors/route";
 
 vi.mock("next-auth", () => ({
   getServerSession: vi.fn(),
@@ -11,14 +11,56 @@ vi.mock("@/lib/registrations", () => ({
   refreshAllContributors: vi.fn(),
 }));
 
+vi.mock("@/lib/audit", () => ({
+  recordAuditLog: vi.fn(),
+}));
+
 import { getServerSession } from "next-auth";
 import { getContributors, refreshAllContributors } from "@/lib/registrations";
+import type { ContributorRow } from "@/types";
 
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
 const sameOriginHeaders: Record<string, string> = {
   origin: "http://localhost:3000",
   host: "localhost:3000",
   "content-type": "application/json",
 };
+
+function makeContributor(
+  id: string,
+  readiness: ContributorRow["readiness"]
+): ContributorRow {
+  return {
+    id,
+    githubUsername: `user-${id}`,
+    stellarAddress: `G${id.padEnd(55, "X")}`,
+    trustlineReady: readiness !== "not_ready",
+    trustlineAuthorized: readiness !== "not_ready",
+    verified: readiness === "ready",
+    funded: readiness !== "not_ready",
+    xlmBalance: readiness === "low_reserve" ? "0.5" : "5",
+    spendableXlmBalance: readiness === "low_reserve" ? "0.1" : "4",
+    lastCheckedAt: new Date().toISOString(),
+    readiness,
+  };
+}
+
+const allContributors: ContributorRow[] = [
+  makeContributor("1", "ready"),
+  makeContributor("2", "ready"),
+  makeContributor("3", "low_reserve"),
+  makeContributor("4", "not_ready"),
+  makeContributor("5", "low_reserve"),
+];
+
+function get(url: string, headers?: Record<string, string>) {
+  return new NextRequest(url, {
+    method: "GET",
+    headers: headers ?? { host: "localhost:3000" },
+  });
+}
 
 function post(headers?: Record<string, string>) {
   return new NextRequest("http://localhost:3000/api/contributors", {
@@ -27,6 +69,152 @@ function post(headers?: Record<string, string>) {
   });
 }
 
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getContributors).mockResolvedValue(allContributors);
+});
+
+// ---------------------------------------------------------------------------
+// GET — auth
+// ---------------------------------------------------------------------------
+describe("GET /api/contributors — auth", () => {
+  it("returns 403 when unauthenticated", async () => {
+    vi.mocked(getServerSession).mockResolvedValue(null);
+    const res = await GET(get("http://localhost:3000/api/contributors"));
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 403 when authenticated but not a maintainer", async () => {
+    vi.mocked(getServerSession).mockResolvedValue({
+      user: { id: "u-1", isMaintainer: false },
+    } as never);
+    const res = await GET(get("http://localhost:3000/api/contributors"));
+    expect(res.status).toBe(403);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET — no filter
+// ---------------------------------------------------------------------------
+describe("GET /api/contributors — no filter", () => {
+  beforeEach(() => {
+    vi.mocked(getServerSession).mockResolvedValue({
+      user: { id: "u-1", isMaintainer: true },
+    } as never);
+  });
+
+  it("returns all contributors when no readiness param is provided", async () => {
+    const res = await GET(get("http://localhost:3000/api/contributors"));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.contributors).toHaveLength(5);
+    expect(json.total).toBe(5);
+    expect(json.filtered).toBe(5);
+    expect(json.readiness).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET — readiness filter
+// ---------------------------------------------------------------------------
+describe("GET /api/contributors — readiness filter", () => {
+  beforeEach(() => {
+    vi.mocked(getServerSession).mockResolvedValue({
+      user: { id: "u-1", isMaintainer: true },
+    } as never);
+  });
+
+  it("filters to only 'ready' contributors", async () => {
+    const res = await GET(
+      get("http://localhost:3000/api/contributors?readiness=ready")
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.contributors).toHaveLength(2);
+    expect(json.filtered).toBe(2);
+    expect(json.total).toBe(5);
+    expect(json.readiness).toBe("ready");
+    for (const c of json.contributors) {
+      expect(c.readiness).toBe("ready");
+    }
+  });
+
+  it("filters to only 'low_reserve' contributors", async () => {
+    const res = await GET(
+      get("http://localhost:3000/api/contributors?readiness=low_reserve")
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.contributors).toHaveLength(2);
+    expect(json.filtered).toBe(2);
+    expect(json.total).toBe(5);
+    expect(json.readiness).toBe("low_reserve");
+    for (const c of json.contributors) {
+      expect(c.readiness).toBe("low_reserve");
+    }
+  });
+
+  it("filters to only 'not_ready' contributors", async () => {
+    const res = await GET(
+      get("http://localhost:3000/api/contributors?readiness=not_ready")
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.contributors).toHaveLength(1);
+    expect(json.filtered).toBe(1);
+    expect(json.total).toBe(5);
+    expect(json.readiness).toBe("not_ready");
+  });
+
+  it("returns 400 for an invalid readiness value", async () => {
+    const res = await GET(
+      get("http://localhost:3000/api/contributors?readiness=invalid")
+    );
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toContain("Invalid readiness filter");
+    expect(json.error).toContain("invalid");
+    expect(json.error).toContain("ready");
+    expect(json.error).toContain("low_reserve");
+    expect(json.error).toContain("not_ready");
+  });
+
+  it("returns 400 for readiness=READY (case-sensitive)", async () => {
+    const res = await GET(
+      get("http://localhost:3000/api/contributors?readiness=READY")
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns empty list when no contributors match the filter", async () => {
+    vi.mocked(getContributors).mockResolvedValue([
+      makeContributor("1", "ready"),
+    ]);
+    const res = await GET(
+      get("http://localhost:3000/api/contributors?readiness=low_reserve")
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.contributors).toHaveLength(0);
+    expect(json.filtered).toBe(0);
+    expect(json.total).toBe(1);
+  });
+
+  it("returns total=0 and filtered=0 when no contributors exist", async () => {
+    vi.mocked(getContributors).mockResolvedValue([]);
+    const res = await GET(
+      get("http://localhost:3000/api/contributors?readiness=low_reserve")
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.total).toBe(0);
+    expect(json.filtered).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST — CSRF + auth
+// ---------------------------------------------------------------------------
 describe("POST /api/contributors", () => {
   it("rejects cross-origin with CSRF error before touching auth", async () => {
     const r = post({
@@ -43,7 +231,7 @@ describe("POST /api/contributors", () => {
   it("returns 403 (auth) for same-origin non-maintainer", async () => {
     vi.mocked(getServerSession).mockResolvedValue({
       user: { id: "user-1", isMaintainer: false },
-    } as any);
+    } as never);
     const r = post();
     const res = await POST(r);
     expect(res.status).toBe(403);
@@ -55,9 +243,9 @@ describe("POST /api/contributors", () => {
   it("returns 200 for same-origin maintainer", async () => {
     vi.mocked(getServerSession).mockResolvedValue({
       user: { id: "user-1", isMaintainer: true },
-    } as any);
+    } as never);
     vi.mocked(refreshAllContributors).mockResolvedValue(3);
-    vi.mocked(getContributors).mockResolvedValue([] as any);
+    vi.mocked(getContributors).mockResolvedValue([] as never);
 
     const r = post();
     const res = await POST(r);

--- a/tests/api/health.test.ts
+++ b/tests/api/health.test.ts
@@ -1,0 +1,219 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { GET } from "@/app/api/health/route";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    $queryRaw: vi.fn(),
+    registration: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/registrations", () => ({
+  toContributorRow: vi.fn((row: unknown) => row),
+}));
+
+vi.mock("@/lib/stale-export", () => ({
+  buildStalenessSummary: vi.fn(),
+}));
+
+import { prisma } from "@/lib/prisma";
+import { buildStalenessSummary } from "@/lib/stale-export";
+import type { HealthResponse } from "@/app/api/health/route";
+
+// Helpers for creating mock data
+function freshSummary() {
+  return {
+    stale: false,
+    staleCount: 0,
+    totalCount: 5,
+    stalePercent: 0,
+    warning: "",
+    allowExport: true,
+  };
+}
+
+function staleSummary() {
+  return {
+    stale: true,
+    staleCount: 2,
+    totalCount: 5,
+    stalePercent: 40,
+    warning: "2 of 5 contributors (40%) have not been verified in the last 24 hour(s).",
+    allowExport: false,
+  };
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe("GET /api/health", () => {
+  it("returns 200 with status=ok when DB is healthy and data is fresh", async () => {
+    vi.mocked(prisma.$queryRaw).mockResolvedValue([{ "?column?": 1 }]);
+    vi.mocked(prisma.registration.findMany).mockResolvedValue([] as never);
+    vi.mocked(buildStalenessSummary).mockReturnValue(freshSummary());
+
+    const res = await GET();
+    const json: HealthResponse = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.status).toBe("ok");
+    expect(json.checks.database.status).toBe("ok");
+    expect(json.checks.database.latencyMs).toBeGreaterThanOrEqual(0);
+    expect(json.checks.csvStaleness.status).toBe("ok");
+    expect(json.checks.csvStaleness.staleCount).toBe(0);
+    expect(json.timestamp).toBeTruthy();
+    expect(json.version).toBeTruthy();
+  });
+
+  it("returns 200 with status=degraded when CSV data is stale", async () => {
+    vi.mocked(prisma.$queryRaw).mockResolvedValue([{ "?column?": 1 }]);
+    vi.mocked(prisma.registration.findMany).mockResolvedValue([] as never);
+    vi.mocked(buildStalenessSummary).mockReturnValue(staleSummary());
+
+    const res = await GET();
+    const json: HealthResponse = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.status).toBe("degraded");
+    expect(json.checks.csvStaleness.status).toBe("degraded");
+    expect(json.checks.csvStaleness.staleCount).toBe(2);
+    expect(json.checks.csvStaleness.totalCount).toBe(5);
+    expect(json.checks.csvStaleness.stalePercent).toBe(40);
+    expect(json.checks.csvStaleness.warning).toContain("2 of 5");
+  });
+
+  it("returns 200 with status=error when DB is unreachable", async () => {
+    vi.mocked(prisma.$queryRaw).mockRejectedValue(new Error("Connection refused"));
+
+    const res = await GET();
+    const json: HealthResponse = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.status).toBe("error");
+    expect(json.checks.database.status).toBe("error");
+    expect(json.checks.database.error).toContain("Connection refused");
+    // Staleness check is skipped when DB is down
+    expect(prisma.registration.findMany).not.toHaveBeenCalled();
+  });
+
+  it("returns 200 with status=degraded when DB is healthy but staleness query fails", async () => {
+    vi.mocked(prisma.$queryRaw).mockResolvedValue([{ "?column?": 1 }]);
+    vi.mocked(prisma.registration.findMany).mockRejectedValue(
+      new Error("Query timeout")
+    );
+
+    const res = await GET();
+    const json: HealthResponse = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.status).toBe("degraded");
+    expect(json.checks.csvStaleness.status).toBe("degraded");
+    expect(json.checks.csvStaleness.warning).toContain("Unable to determine");
+  });
+
+  it("includes a version field in the response", async () => {
+    vi.mocked(prisma.$queryRaw).mockResolvedValue([{ "?column?": 1 }]);
+    vi.mocked(prisma.registration.findMany).mockResolvedValue([] as never);
+    vi.mocked(buildStalenessSummary).mockReturnValue(freshSummary());
+
+    const res = await GET();
+    const json: HealthResponse = await res.json();
+
+    expect(typeof json.version).toBe("string");
+    expect(json.version.length).toBeGreaterThan(0);
+  });
+
+  it("includes an ISO-8601 timestamp in the response", async () => {
+    vi.mocked(prisma.$queryRaw).mockResolvedValue([{ "?column?": 1 }]);
+    vi.mocked(prisma.registration.findMany).mockResolvedValue([] as never);
+    vi.mocked(buildStalenessSummary).mockReturnValue(freshSummary());
+
+    const before = Date.now();
+    const res = await GET();
+    const after = Date.now();
+    const json: HealthResponse = await res.json();
+
+    const ts = new Date(json.timestamp).getTime();
+    expect(ts).toBeGreaterThanOrEqual(before);
+    expect(ts).toBeLessThanOrEqual(after);
+  });
+
+  it("does not expose PII in the response body", async () => {
+    vi.mocked(prisma.$queryRaw).mockResolvedValue([{ "?column?": 1 }]);
+    vi.mocked(prisma.registration.findMany).mockResolvedValue([] as never);
+    vi.mocked(buildStalenessSummary).mockReturnValue(staleSummary());
+
+    const res = await GET();
+    const text = await res.text();
+
+    // The body must not contain typical PII fields
+    expect(text).not.toContain("githubUsername");
+    expect(text).not.toContain("stellarAddress");
+    expect(text).not.toContain("accessToken");
+    expect(text).not.toContain("email");
+  });
+
+  it("reports database latency as a non-negative number", async () => {
+    vi.mocked(prisma.$queryRaw).mockResolvedValue([{ "?column?": 1 }]);
+    vi.mocked(prisma.registration.findMany).mockResolvedValue([] as never);
+    vi.mocked(buildStalenessSummary).mockReturnValue(freshSummary());
+
+    const res = await GET();
+    const json: HealthResponse = await res.json();
+
+    expect(json.checks.database.latencyMs).toBeGreaterThanOrEqual(0);
+    expect(Number.isFinite(json.checks.database.latencyMs)).toBe(true);
+  });
+
+  it("does not include error field in database check when DB is healthy", async () => {
+    vi.mocked(prisma.$queryRaw).mockResolvedValue([{ "?column?": 1 }]);
+    vi.mocked(prisma.registration.findMany).mockResolvedValue([] as never);
+    vi.mocked(buildStalenessSummary).mockReturnValue(freshSummary());
+
+    const res = await GET();
+    const json: HealthResponse = await res.json();
+
+    expect(json.checks.database.error).toBeUndefined();
+  });
+
+  it("skips staleness check when DB reports error (error takes priority)", async () => {
+    vi.mocked(prisma.$queryRaw).mockRejectedValue(new Error("Timeout"));
+
+    const res = await GET();
+    const json: HealthResponse = await res.json();
+
+    // Registration query should never be called
+    expect(prisma.registration.findMany).not.toHaveBeenCalled();
+    // Overall status must be "error", not "degraded"
+    expect(json.status).toBe("error");
+  });
+
+  it("csvStaleness reflects all-stale scenario (stalePercent=100)", async () => {
+    vi.mocked(prisma.$queryRaw).mockResolvedValue([{ "?column?": 1 }]);
+    vi.mocked(prisma.registration.findMany).mockResolvedValue([] as never);
+    vi.mocked(buildStalenessSummary).mockReturnValue({
+      stale: true,
+      staleCount: 3,
+      totalCount: 3,
+      stalePercent: 100,
+      warning: "3 of 3 contributors (100%) have not been verified.",
+      allowExport: false,
+    });
+
+    const res = await GET();
+    const json: HealthResponse = await res.json();
+
+    expect(json.checks.csvStaleness.stalePercent).toBe(100);
+    expect(json.checks.csvStaleness.staleCount).toBe(3);
+    expect(json.status).toBe("degraded");
+  });
+});

--- a/tests/api/integration-auth.test.ts
+++ b/tests/api/integration-auth.test.ts
@@ -1,0 +1,306 @@
+/**
+ * API integration tests — auth roles, tokens, and edge cases (#45)
+ *
+ * Part 1: /api/register (GET + POST) and role-based access patterns
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { GET, POST } from "@/app/api/register/route";
+
+vi.mock("next-auth", () => ({ getServerSession: vi.fn() }));
+vi.mock("@/lib/horizon", () => ({ checkStellarAddress: vi.fn() }));
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    registration: { findUnique: vi.fn(), upsert: vi.fn() },
+  },
+}));
+vi.mock("@/lib/stellar", () => ({ isValidStellarAddress: vi.fn() }));
+vi.mock("@/lib/audit", () => ({ recordAuditLog: vi.fn() }));
+
+import { getServerSession } from "next-auth";
+import { checkStellarAddress } from "@/lib/horizon";
+import { prisma } from "@/lib/prisma";
+import { isValidStellarAddress } from "@/lib/stellar";
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+const SAME_ORIGIN = {
+  origin: "http://localhost:3000",
+  host: "localhost:3000",
+  "content-type": "application/json",
+};
+
+const CROSS_ORIGIN = {
+  origin: "https://evil.com",
+  host: "localhost:3000",
+  "content-type": "application/json",
+};
+
+function postRegister(body: unknown, headers = SAME_ORIGIN) {
+  return new NextRequest("http://localhost:3000/api/register", {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+}
+
+function mockSession(opts: { id?: string; isMaintainer?: boolean } = {}) {
+  vi.mocked(getServerSession).mockResolvedValue({
+    user: { id: opts.id ?? "user-1", isMaintainer: opts.isMaintainer ?? false },
+  } as never);
+}
+
+function mockHorizonReady() {
+  vi.mocked(checkStellarAddress).mockResolvedValue({
+    funded: true,
+    trustline: true,
+    trustline_authorized: true,
+    verified: true,
+    xlm_balance: "5",
+    spendable_xlm_balance: "4",
+    errors: [],
+    readiness: "ready",
+  } as never);
+}
+
+const VALID_ADDRESS = "GBSX" + "X".repeat(52);
+
+afterEach(() => vi.clearAllMocks());
+
+// ---------------------------------------------------------------------------
+// POST /api/register — CSRF
+// ---------------------------------------------------------------------------
+describe("POST /api/register — CSRF protection", () => {
+  it("rejects cross-origin before touching session or DB", async () => {
+    const res = await POST(postRegister({ stellarAddress: VALID_ADDRESS }, CROSS_ORIGIN));
+    expect(res.status).toBe(403);
+    expect(getServerSession).not.toHaveBeenCalled();
+    expect(prisma.registration.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("allows a request with no Origin/Referer (non-browser API client)", async () => {
+    vi.mocked(getServerSession).mockResolvedValue(null);
+    const req = new NextRequest("http://localhost:3000/api/register", {
+      method: "POST",
+      headers: { host: "localhost:3000", "content-type": "application/json" },
+      body: JSON.stringify({ stellarAddress: VALID_ADDRESS }),
+    });
+    const res = await POST(req);
+    // Unauthenticated but CSRF passed — 401 not 403
+    expect(res.status).toBe(401);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/register — auth
+// ---------------------------------------------------------------------------
+describe("POST /api/register — authentication", () => {
+  it("returns 401 when unauthenticated", async () => {
+    vi.mocked(getServerSession).mockResolvedValue(null);
+    const res = await POST(postRegister({ stellarAddress: VALID_ADDRESS }));
+    expect(res.status).toBe(401);
+  });
+
+  it("allows contributor (non-maintainer) to register", async () => {
+    mockSession({ isMaintainer: false });
+    vi.mocked(isValidStellarAddress).mockReturnValue(true);
+    vi.mocked(prisma.registration.findUnique).mockResolvedValue(null);
+    mockHorizonReady();
+    vi.mocked(prisma.registration.upsert).mockResolvedValue({
+      id: "reg-1",
+      userId: "user-1",
+      stellarAddress: VALID_ADDRESS,
+      funded: true,
+      trustlineReady: true,
+      trustlineAuthorized: true,
+      xlmBalance: "5",
+      spendableXlmBalance: "4",
+      lastCheckedAt: new Date(),
+    } as never);
+
+    const res = await POST(postRegister({ stellarAddress: VALID_ADDRESS }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.success).toBe(true);
+    expect(json.registration.stellarAddress).toBe(VALID_ADDRESS);
+  });
+
+  it("allows maintainer to register (no special block)", async () => {
+    mockSession({ isMaintainer: true });
+    vi.mocked(isValidStellarAddress).mockReturnValue(true);
+    vi.mocked(prisma.registration.findUnique).mockResolvedValue(null);
+    mockHorizonReady();
+    vi.mocked(prisma.registration.upsert).mockResolvedValue({
+      id: "reg-2",
+      userId: "user-1",
+      stellarAddress: VALID_ADDRESS,
+      funded: true,
+      trustlineReady: true,
+      trustlineAuthorized: true,
+      xlmBalance: "5",
+      spendableXlmBalance: "4",
+      lastCheckedAt: new Date(),
+    } as never);
+
+    const res = await POST(postRegister({ stellarAddress: VALID_ADDRESS }));
+    expect(res.status).toBe(200);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/register — validation
+// ---------------------------------------------------------------------------
+describe("POST /api/register — input validation", () => {
+  beforeEach(() => mockSession());
+
+  it("returns 400 for missing address", async () => {
+    const res = await POST(postRegister({}));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for empty string address", async () => {
+    const res = await POST(postRegister({ stellarAddress: "   " }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for an invalid G-address", async () => {
+    vi.mocked(isValidStellarAddress).mockReturnValue(false);
+    const res = await POST(postRegister({ stellarAddress: "not-a-stellar-address" }));
+    expect(res.status).toBe(400);
+    expect(checkStellarAddress).not.toHaveBeenCalled();
+  });
+
+  it("returns 409 when address is already registered to another user", async () => {
+    mockSession({ id: "user-2" });
+    vi.mocked(isValidStellarAddress).mockReturnValue(true);
+    vi.mocked(prisma.registration.findUnique).mockResolvedValue({
+      id: "reg-existing",
+      userId: "user-1", // different user
+      stellarAddress: VALID_ADDRESS,
+    } as never);
+
+    const res = await POST(postRegister({ stellarAddress: VALID_ADDRESS }));
+    expect(res.status).toBe(409);
+    const json = await res.json();
+    expect(json.error).toContain("already registered");
+  });
+
+  it("allows re-registration to the same user (address update)", async () => {
+    mockSession({ id: "user-1" });
+    vi.mocked(isValidStellarAddress).mockReturnValue(true);
+    vi.mocked(prisma.registration.findUnique).mockResolvedValue({
+      id: "reg-1",
+      userId: "user-1", // same user
+      stellarAddress: VALID_ADDRESS,
+    } as never);
+    mockHorizonReady();
+    vi.mocked(prisma.registration.upsert).mockResolvedValue({
+      id: "reg-1",
+      userId: "user-1",
+      stellarAddress: VALID_ADDRESS,
+      funded: true,
+      trustlineReady: true,
+      trustlineAuthorized: true,
+      xlmBalance: "5",
+      spendableXlmBalance: "4",
+      lastCheckedAt: new Date(),
+    } as never);
+
+    const res = await POST(postRegister({ stellarAddress: VALID_ADDRESS }));
+    expect(res.status).toBe(200);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/register — readiness propagation
+// ---------------------------------------------------------------------------
+describe("POST /api/register — readiness in response", () => {
+  beforeEach(() => {
+    mockSession();
+    vi.mocked(isValidStellarAddress).mockReturnValue(true);
+    vi.mocked(prisma.registration.findUnique).mockResolvedValue(null);
+  });
+
+  it("reflects 'ready' when Horizon confirms funding + authorized trustline", async () => {
+    mockHorizonReady();
+    vi.mocked(prisma.registration.upsert).mockResolvedValue({
+      id: "r1", userId: "user-1", stellarAddress: VALID_ADDRESS,
+      funded: true, trustlineReady: true, trustlineAuthorized: true,
+      xlmBalance: "5", spendableXlmBalance: "4", lastCheckedAt: new Date(),
+    } as never);
+
+    const json = await (await POST(postRegister({ stellarAddress: VALID_ADDRESS }))).json();
+    expect(json.registration.readiness).toBe("ready");
+    expect(json.registration.verified).toBe(true);
+  });
+
+  it("reflects 'low_reserve' when spendable XLM is below threshold", async () => {
+    vi.mocked(checkStellarAddress).mockResolvedValue({
+      funded: true, trustline: true, trustline_authorized: true,
+      verified: true, xlm_balance: "1.5", spendable_xlm_balance: "0.1",
+      errors: [], readiness: "low_reserve",
+    } as never);
+    vi.mocked(prisma.registration.upsert).mockResolvedValue({
+      id: "r2", userId: "user-1", stellarAddress: VALID_ADDRESS,
+      funded: true, trustlineReady: true, trustlineAuthorized: true,
+      xlmBalance: "1.5", spendableXlmBalance: "0.1", lastCheckedAt: new Date(),
+    } as never);
+
+    const json = await (await POST(postRegister({ stellarAddress: VALID_ADDRESS }))).json();
+    expect(json.registration.readiness).toBe("low_reserve");
+  });
+
+  it("reflects 'not_ready' for unauthorized trustline", async () => {
+    vi.mocked(checkStellarAddress).mockResolvedValue({
+      funded: true, trustline: true, trustline_authorized: false,
+      verified: false, xlm_balance: "5", spendable_xlm_balance: "4",
+      errors: [], readiness: "not_ready",
+    } as never);
+    vi.mocked(prisma.registration.upsert).mockResolvedValue({
+      id: "r3", userId: "user-1", stellarAddress: VALID_ADDRESS,
+      funded: true, trustlineReady: true, trustlineAuthorized: false,
+      xlmBalance: "5", spendableXlmBalance: "4", lastCheckedAt: new Date(),
+    } as never);
+
+    const json = await (await POST(postRegister({ stellarAddress: VALID_ADDRESS }))).json();
+    expect(json.registration.readiness).toBe("not_ready");
+    expect(json.registration.verified).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/register
+// ---------------------------------------------------------------------------
+describe("GET /api/register", () => {
+  it("returns 401 when unauthenticated", async () => {
+    vi.mocked(getServerSession).mockResolvedValue(null);
+    const res = await GET();
+    expect(res.status).toBe(401);
+  });
+
+  it("returns null registration when none exists yet", async () => {
+    mockSession();
+    vi.mocked(prisma.registration.findUnique).mockResolvedValue(null);
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.registration).toBeNull();
+  });
+
+  it("returns existing registration for authenticated user", async () => {
+    mockSession({ id: "user-1" });
+    vi.mocked(prisma.registration.findUnique).mockResolvedValue({
+      id: "reg-1",
+      userId: "user-1",
+      stellarAddress: VALID_ADDRESS,
+      funded: true,
+      trustlineReady: true,
+    } as never);
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.registration.stellarAddress).toBe(VALID_ADDRESS);
+  });
+});

--- a/tests/api/integration-maintainer.test.ts
+++ b/tests/api/integration-maintainer.test.ts
@@ -1,0 +1,321 @@
+/**
+ * API integration tests — auth roles, tokens, and edge cases (#45)
+ *
+ * Part 2: maintainer-only routes (/api/contributors, /api/contributors/[id],
+ *         /api/audit) — role enforcement, token edge cases, and error paths
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("next-auth", () => ({ getServerSession: vi.fn() }));
+vi.mock("@/lib/registrations", () => ({
+  getContributors: vi.fn(),
+  refreshAllContributors: vi.fn(),
+  refreshContributor: vi.fn(),
+}));
+vi.mock("@/lib/audit", () => ({
+  recordAuditLog: vi.fn(),
+  getRecentAuditLog: vi.fn(),
+}));
+vi.mock("@/lib/audit-format", () => ({ summarizeAuditLog: vi.fn(() => ({})) }));
+
+import { getServerSession } from "next-auth";
+import {
+  getContributors,
+  refreshAllContributors,
+  refreshContributor,
+} from "@/lib/registrations";
+import { getRecentAuditLog } from "@/lib/audit";
+
+import { GET as getContributorsRoute, POST as postContributorsRoute } from "@/app/api/contributors/route";
+import { POST as recheckSingle } from "@/app/api/contributors/[id]/route";
+import { GET as getAudit } from "@/app/api/audit/route";
+
+import type { ContributorRow } from "@/types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+const SAME_ORIGIN = {
+  origin: "http://localhost:3000",
+  host: "localhost:3000",
+  "content-type": "application/json",
+};
+
+function makeContributor(
+  id: string,
+  readiness: ContributorRow["readiness"] = "ready"
+): ContributorRow {
+  return {
+    id,
+    githubUsername: `user-${id}`,
+    stellarAddress: `G${id.padEnd(55, "X")}`,
+    trustlineReady: readiness !== "not_ready",
+    trustlineAuthorized: readiness !== "not_ready",
+    verified: readiness === "ready",
+    funded: readiness !== "not_ready",
+    xlmBalance: "5",
+    spendableXlmBalance: "4",
+    lastCheckedAt: new Date().toISOString(),
+    readiness,
+  };
+}
+
+function mockMaintainer(id = "m-1", login = "maintainer") {
+  vi.mocked(getServerSession).mockResolvedValue({
+    user: { id, githubUsername: login, isMaintainer: true },
+  } as never);
+}
+
+function mockContributor(id = "u-1") {
+  vi.mocked(getServerSession).mockResolvedValue({
+    user: { id, isMaintainer: false },
+  } as never);
+}
+
+function mockUnauthenticated() {
+  vi.mocked(getServerSession).mockResolvedValue(null);
+}
+
+afterEach(() => vi.clearAllMocks());
+
+// ---------------------------------------------------------------------------
+// GET /api/contributors — role enforcement
+// ---------------------------------------------------------------------------
+describe("GET /api/contributors — role enforcement", () => {
+  it("returns 403 for unauthenticated requests", async () => {
+    mockUnauthenticated();
+    const req = new NextRequest("http://localhost:3000/api/contributors");
+    const res = await getContributorsRoute(req);
+    expect(res.status).toBe(403);
+    expect(getContributors).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 for contributor (non-maintainer) role", async () => {
+    mockContributor();
+    const req = new NextRequest("http://localhost:3000/api/contributors");
+    const res = await getContributorsRoute(req);
+    expect(res.status).toBe(403);
+    expect(getContributors).not.toHaveBeenCalled();
+  });
+
+  it("returns 200 for maintainer role", async () => {
+    mockMaintainer();
+    vi.mocked(getContributors).mockResolvedValue([makeContributor("1")]);
+    const req = new NextRequest("http://localhost:3000/api/contributors");
+    const res = await getContributorsRoute(req);
+    expect(res.status).toBe(200);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/contributors — readiness filter (low_reserve focus)
+// ---------------------------------------------------------------------------
+describe("GET /api/contributors — readiness filter", () => {
+  const fixtures = [
+    makeContributor("1", "ready"),
+    makeContributor("2", "low_reserve"),
+    makeContributor("3", "not_ready"),
+  ];
+
+  it("returns all contributors when no filter is applied", async () => {
+    mockMaintainer();
+    vi.mocked(getContributors).mockResolvedValue(fixtures);
+    const req = new NextRequest("http://localhost:3000/api/contributors");
+    const json = await (await getContributorsRoute(req)).json();
+    expect(json.contributors).toHaveLength(3);
+    expect(json.total).toBe(3);
+    expect(json.filtered).toBe(3);
+    expect(json.readiness).toBeUndefined();
+  });
+
+  it("isolates low_reserve contributors via ?readiness=low_reserve", async () => {
+    mockMaintainer();
+    vi.mocked(getContributors).mockResolvedValue(fixtures);
+    const req = new NextRequest(
+      "http://localhost:3000/api/contributors?readiness=low_reserve"
+    );
+    const json = await (await getContributorsRoute(req)).json();
+    expect(json.contributors).toHaveLength(1);
+    expect(json.contributors[0].readiness).toBe("low_reserve");
+    expect(json.readiness).toBe("low_reserve");
+    expect(json.total).toBe(3);
+    expect(json.filtered).toBe(1);
+  });
+
+  it("returns 400 for unknown readiness value", async () => {
+    mockMaintainer();
+    const req = new NextRequest(
+      "http://localhost:3000/api/contributors?readiness=unknown"
+    );
+    const res = await getContributorsRoute(req);
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toContain("Invalid readiness filter");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/contributors — batch recheck
+// ---------------------------------------------------------------------------
+describe("POST /api/contributors — batch recheck", () => {
+  it("rejects cross-origin requests (CSRF)", async () => {
+    const req = new NextRequest("http://localhost:3000/api/contributors", {
+      method: "POST",
+      headers: { origin: "https://attacker.com", host: "localhost:3000" },
+    });
+    const res = await postContributorsRoute(req);
+    expect(res.status).toBe(403);
+    const json = await res.json();
+    expect(json.error).toBe("Invalid request origin");
+    expect(getServerSession).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 for non-maintainer on same-origin", async () => {
+    mockContributor();
+    const req = new NextRequest("http://localhost:3000/api/contributors", {
+      method: "POST",
+      headers: SAME_ORIGIN,
+    });
+    const res = await postContributorsRoute(req);
+    expect(res.status).toBe(403);
+    expect(refreshAllContributors).not.toHaveBeenCalled();
+  });
+
+  it("runs batch recheck and returns count + contributors for maintainer", async () => {
+    mockMaintainer();
+    vi.mocked(refreshAllContributors).mockResolvedValue(4);
+    vi.mocked(getContributors).mockResolvedValue([makeContributor("1")]);
+    const req = new NextRequest("http://localhost:3000/api/contributors", {
+      method: "POST",
+      headers: SAME_ORIGIN,
+    });
+    const res = await postContributorsRoute(req);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.refreshed).toBe(4);
+    expect(Array.isArray(json.contributors)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/contributors/[id] — single recheck
+// ---------------------------------------------------------------------------
+describe("POST /api/contributors/[id] — single contributor recheck", () => {
+  it("returns 403 when unauthenticated", async () => {
+    mockUnauthenticated();
+    const res = await recheckSingle(new Request("http://localhost:3000"), {
+      params: { id: "reg-1" },
+    });
+    expect(res.status).toBe(403);
+    expect(refreshContributor).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 for contributor (non-maintainer) role", async () => {
+    mockContributor();
+    const res = await recheckSingle(new Request("http://localhost:3000"), {
+      params: { id: "reg-1" },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 400 when id param is empty", async () => {
+    mockMaintainer();
+    const res = await recheckSingle(new Request("http://localhost:3000"), {
+      params: { id: "" },
+    });
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toContain("required");
+  });
+
+  it("returns 404 when contributor does not exist", async () => {
+    mockMaintainer();
+    vi.mocked(refreshContributor).mockResolvedValue(null);
+    const res = await recheckSingle(new Request("http://localhost:3000"), {
+      params: { id: "nonexistent" },
+    });
+    expect(res.status).toBe(404);
+    const json = await res.json();
+    expect(json.error).toContain("not found");
+  });
+
+  it("returns 200 with refreshed contributor for maintainer", async () => {
+    mockMaintainer();
+    const contributor = makeContributor("reg-1", "ready");
+    vi.mocked(refreshContributor).mockResolvedValue(contributor);
+    const res = await recheckSingle(new Request("http://localhost:3000"), {
+      params: { id: "reg-1" },
+    });
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.contributor.id).toBe("reg-1");
+    expect(json.contributor.readiness).toBe("ready");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/audit — role enforcement
+// ---------------------------------------------------------------------------
+describe("GET /api/audit — role enforcement", () => {
+  it("returns 403 for unauthenticated requests", async () => {
+    mockUnauthenticated();
+    const req = new NextRequest("http://localhost:3000/api/audit");
+    const res = await getAudit(req);
+    expect(res.status).toBe(403);
+    expect(getRecentAuditLog).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 for contributor (non-maintainer)", async () => {
+    mockContributor();
+    const req = new NextRequest("http://localhost:3000/api/audit");
+    const res = await getAudit(req);
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 200 with entries for maintainer", async () => {
+    mockMaintainer();
+    vi.mocked(getRecentAuditLog).mockResolvedValue([
+      {
+        id: "log-1",
+        action: "recheck.batch",
+        actorId: "m-1",
+        actorLogin: "maintainer",
+        targetId: null,
+        targetLabel: null,
+        metadata: { refreshed: 3 },
+        createdAt: new Date().toISOString(),
+      },
+    ]);
+    const req = new NextRequest("http://localhost:3000/api/audit");
+    const res = await getAudit(req);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(Array.isArray(json.entries)).toBe(true);
+    expect(json.entries[0].action).toBe("recheck.batch");
+  });
+
+  it("respects ?limit param and caps at max", async () => {
+    mockMaintainer();
+    vi.mocked(getRecentAuditLog).mockResolvedValue([]);
+    const req = new NextRequest("http://localhost:3000/api/audit?limit=10");
+    await getAudit(req);
+    expect(getRecentAuditLog).toHaveBeenCalledWith(10);
+  });
+
+  it("uses default limit of 50 when not specified", async () => {
+    mockMaintainer();
+    vi.mocked(getRecentAuditLog).mockResolvedValue([]);
+    const req = new NextRequest("http://localhost:3000/api/audit");
+    await getAudit(req);
+    expect(getRecentAuditLog).toHaveBeenCalledWith(50);
+  });
+
+  it("ignores invalid (non-numeric) limit and uses default", async () => {
+    mockMaintainer();
+    vi.mocked(getRecentAuditLog).mockResolvedValue([]);
+    const req = new NextRequest("http://localhost:3000/api/audit?limit=abc");
+    await getAudit(req);
+    expect(getRecentAuditLog).toHaveBeenCalledWith(50);
+  });
+});

--- a/tests/api/integration-tokens-edge.test.ts
+++ b/tests/api/integration-tokens-edge.test.ts
@@ -1,0 +1,348 @@
+/**
+ * API integration tests — auth roles, tokens, and edge cases (#45)
+ *
+ * Part 3: token encryption flows, /api/check, /api/stats, /api/health,
+ *         and cross-cutting edge cases (rate limiting, error propagation)
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+vi.mock("next-auth", () => ({ getServerSession: vi.fn() }));
+vi.mock("@/lib/horizon", () => ({ checkStellarAddress: vi.fn() }));
+vi.mock("@/lib/rate-limit", () => ({
+  extractClientIp: vi.fn(() => "127.0.0.1"),
+  checkRateLimit: vi.fn(() => ({ allowed: true, retryAfter: 0, remaining: 9 })),
+  resetRateLimit: vi.fn(),
+}));
+vi.mock("@/lib/registrations", () => ({
+  getDashboardStats: vi.fn(),
+  toContributorRow: vi.fn((r: unknown) => r),
+}));
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    $queryRaw: vi.fn(),
+    registration: { findMany: vi.fn() },
+  },
+}));
+vi.mock("@/lib/stale-export", () => ({
+  buildStalenessSummary: vi.fn(),
+}));
+vi.mock("@/lib/token-crypto", () => ({
+  encryptToken: vi.fn((t: string) => `enc:${t}`),
+  decryptToken: vi.fn((t: string) => t.replace("enc:", "")),
+}));
+vi.mock("@/lib/token-audit", () => ({ recordTokenAudit: vi.fn() }));
+vi.mock("@/lib/audit", () => ({ recordAuditLog: vi.fn() }));
+
+import { getServerSession } from "next-auth";
+import { checkStellarAddress } from "@/lib/horizon";
+import { checkRateLimit, resetRateLimit } from "@/lib/rate-limit";
+import { getDashboardStats } from "@/lib/registrations";
+import { prisma } from "@/lib/prisma";
+import { buildStalenessSummary } from "@/lib/stale-export";
+
+import { POST as checkPost } from "@/app/api/check/route";
+import { GET as statsGet } from "@/app/api/stats/route";
+import { GET as healthGet } from "@/app/api/health/route";
+
+// ---------------------------------------------------------------------------
+// Shared fixtures
+// ---------------------------------------------------------------------------
+const SAME_ORIGIN_HEADERS = {
+  origin: "http://localhost:3000",
+  host: "localhost:3000",
+  "content-type": "application/json",
+};
+
+function postCheck(body: unknown, headers = SAME_ORIGIN_HEADERS) {
+  return new NextRequest("http://localhost:3000/api/check", {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+}
+
+function mockHorizonReady() {
+  vi.mocked(checkStellarAddress).mockResolvedValue({
+    funded: true,
+    trustline: true,
+    trustline_authorized: true,
+    verified: true,
+    xlm_balance: "5",
+    spendable_xlm_balance: "4",
+    errors: [],
+    readiness: "ready",
+  } as never);
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/check — CSRF + rate limit
+// ---------------------------------------------------------------------------
+describe("POST /api/check — CSRF protection", () => {
+  it("rejects cross-origin before touching Horizon", async () => {
+    const res = await checkPost(
+      postCheck({ address: "GBSX" }, {
+        origin: "https://evil.com",
+        host: "localhost:3000",
+        "content-type": "application/json",
+      })
+    );
+    expect(res.status).toBe(403);
+    expect(checkStellarAddress).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for missing address (same-origin)", async () => {
+    const res = await checkPost(postCheck({ address: "" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 200 with readiness for a valid address", async () => {
+    mockHorizonReady();
+    const res = await checkPost(postCheck({ address: "GBSX" + "X".repeat(52) }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.funded).toBe(true);
+    expect(json.readiness).toBe("ready");
+  });
+
+  it("returns 200 with Horizon errors forwarded (circuit-breaker open)", async () => {
+    vi.mocked(checkStellarAddress).mockResolvedValue({
+      funded: false,
+      trustline: false,
+      trustline_authorized: false,
+      verified: false,
+      xlm_balance: "0",
+      spendable_xlm_balance: "0",
+      errors: ["Horizon is temporarily unavailable. Please try again later."],
+      readiness: "not_ready",
+    } as never);
+    const res = await checkPost(postCheck({ address: "GBSX" + "X".repeat(52) }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.errors).toContain(
+      "Horizon is temporarily unavailable. Please try again later."
+    );
+  });
+});
+
+describe("POST /api/check — rate limiting", () => {
+  it("returns 429 when rate limit is exhausted", async () => {
+    vi.mocked(checkRateLimit).mockReturnValue({
+      allowed: false,
+      retryAfter: 42,
+      remaining: 0,
+    });
+    const res = await checkPost(postCheck({ address: "GBSX" }));
+    expect(res.status).toBe(429);
+    expect(res.headers.get("retry-after")).toBe("42");
+    expect(checkStellarAddress).not.toHaveBeenCalled();
+  });
+
+  it("returns 200 when rate limit has remaining capacity", async () => {
+    vi.mocked(checkRateLimit).mockReturnValue({
+      allowed: true,
+      retryAfter: 0,
+      remaining: 5,
+    });
+    mockHorizonReady();
+    const res = await checkPost(postCheck({ address: "GBSX" + "X".repeat(52) }));
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("POST /api/check — Horizon error propagation", () => {
+  it("returns 500 when checkStellarAddress throws unexpectedly", async () => {
+    vi.mocked(checkStellarAddress).mockRejectedValue(new Error("Unexpected boom"));
+    const res = await checkPost(postCheck({ address: "GBSX" + "X".repeat(52) }));
+    expect(res.status).toBe(500);
+  });
+
+  it("forwards custom asset_code and asset_issuer to checkStellarAddress", async () => {
+    mockHorizonReady();
+    await checkPost(
+      postCheck({
+        address: "GBSX" + "X".repeat(52),
+        asset_code: "XLM",
+        asset_issuer: "native",
+      })
+    );
+    expect(checkStellarAddress).toHaveBeenCalledWith(
+      expect.any(String),
+      "XLM",
+      "native"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/stats — public endpoint
+// ---------------------------------------------------------------------------
+describe("GET /api/stats — public, no auth required", () => {
+  it("returns 200 with aggregate stats", async () => {
+    vi.mocked(getDashboardStats).mockResolvedValue({
+      totalContributors: 10,
+      readyCount: 7,
+      readyPercent: 70,
+    });
+    const res = await statsGet();
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.totalContributors).toBe(10);
+    expect(json.readyCount).toBe(7);
+    expect(json.readyPercent).toBe(70);
+  });
+
+  it("returns 200 with zero stats when no contributors exist", async () => {
+    vi.mocked(getDashboardStats).mockResolvedValue({
+      totalContributors: 0,
+      readyCount: 0,
+      readyPercent: 0,
+    });
+    const res = await statsGet();
+    const json = await res.json();
+    expect(json.totalContributors).toBe(0);
+    expect(json.readyPercent).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/health — always 200, unauthenticated
+// ---------------------------------------------------------------------------
+describe("GET /api/health — always 200, unauthenticated", () => {
+  it("returns 200 (not 401/403) even without a session", async () => {
+    vi.mocked(getServerSession).mockResolvedValue(null);
+    vi.mocked(prisma.$queryRaw).mockResolvedValue([]);
+    vi.mocked(prisma.registration.findMany).mockResolvedValue([]);
+    vi.mocked(buildStalenessSummary).mockReturnValue({
+      stale: false, staleCount: 0, totalCount: 0,
+      stalePercent: 0, warning: "", allowExport: true,
+    });
+    const res = await healthGet();
+    expect(res.status).toBe(200);
+  });
+
+  it("reports status=ok when DB healthy and data fresh", async () => {
+    vi.mocked(prisma.$queryRaw).mockResolvedValue([]);
+    vi.mocked(prisma.registration.findMany).mockResolvedValue([]);
+    vi.mocked(buildStalenessSummary).mockReturnValue({
+      stale: false, staleCount: 0, totalCount: 3,
+      stalePercent: 0, warning: "", allowExport: true,
+    });
+    const res = await healthGet();
+    const json = await res.json();
+    expect(json.status).toBe("ok");
+    expect(json.checks.database.status).toBe("ok");
+    expect(json.checks.csvStaleness.status).toBe("ok");
+  });
+
+  it("reports status=degraded when contributor data is stale", async () => {
+    vi.mocked(prisma.$queryRaw).mockResolvedValue([]);
+    vi.mocked(prisma.registration.findMany).mockResolvedValue([]);
+    vi.mocked(buildStalenessSummary).mockReturnValue({
+      stale: true, staleCount: 2, totalCount: 5,
+      stalePercent: 40,
+      warning: "2 of 5 contributors not verified recently.",
+      allowExport: false,
+    });
+    const res = await healthGet();
+    const json = await res.json();
+    expect(json.status).toBe("degraded");
+    expect(json.checks.csvStaleness.staleCount).toBe(2);
+  });
+
+  it("reports status=error (still 200) when DB is unreachable", async () => {
+    vi.mocked(prisma.$queryRaw).mockRejectedValue(new Error("ECONNREFUSED"));
+    const res = await healthGet();
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.status).toBe("error");
+    expect(json.checks.database.status).toBe("error");
+    expect(json.checks.database.error).toContain("ECONNREFUSED");
+  });
+
+  it("does not expose PII in health response", async () => {
+    vi.mocked(prisma.$queryRaw).mockResolvedValue([]);
+    vi.mocked(prisma.registration.findMany).mockResolvedValue([]);
+    vi.mocked(buildStalenessSummary).mockReturnValue({
+      stale: false, staleCount: 0, totalCount: 0,
+      stalePercent: 0, warning: "", allowExport: true,
+    });
+    const res = await healthGet();
+    const text = await res.text();
+    expect(text).not.toContain("githubUsername");
+    expect(text).not.toContain("stellarAddress");
+    expect(text).not.toContain("accessToken");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Token encryption — getDecryptedGithubAccessToken edge cases
+// ---------------------------------------------------------------------------
+describe("token encryption — getDecryptedGithubAccessToken", () => {
+  // Import lazily so mocks are applied first
+  it("returns null when no access token is stored for the user", async () => {
+    const prismaModule = await vi.importMock("@/lib/prisma") as {
+      prisma: { user: { findUnique: ReturnType<typeof vi.fn> } };
+    };
+    prismaModule.prisma.user = {
+      findUnique: vi.fn().mockResolvedValue({ accessToken: null }),
+    };
+
+    const { getDecryptedGithubAccessToken } = await import("@/lib/auth");
+    const result = await getDecryptedGithubAccessToken("user-no-token");
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cross-cutting: response shape consistency
+// ---------------------------------------------------------------------------
+describe("response shape — API contracts", () => {
+  it("POST /api/check always includes funded, trustline, verified, readiness", async () => {
+    mockHorizonReady();
+    const res = await checkPost(postCheck({ address: "GBSX" + "X".repeat(52) }));
+    const json = await res.json();
+    expect(json).toHaveProperty("funded");
+    expect(json).toHaveProperty("trustline");
+    expect(json).toHaveProperty("verified");
+    expect(json).toHaveProperty("readiness");
+    expect(json).toHaveProperty("errors");
+    expect(Array.isArray(json.errors)).toBe(true);
+  });
+
+  it("GET /api/health always includes status, timestamp, version, checks", async () => {
+    vi.mocked(prisma.$queryRaw).mockResolvedValue([]);
+    vi.mocked(prisma.registration.findMany).mockResolvedValue([]);
+    vi.mocked(buildStalenessSummary).mockReturnValue({
+      stale: false, staleCount: 0, totalCount: 0,
+      stalePercent: 0, warning: "", allowExport: true,
+    });
+    const res = await healthGet();
+    const json = await res.json();
+    expect(json).toHaveProperty("status");
+    expect(json).toHaveProperty("timestamp");
+    expect(json).toHaveProperty("version");
+    expect(json).toHaveProperty("checks");
+    expect(json.checks).toHaveProperty("database");
+    expect(json.checks).toHaveProperty("csvStaleness");
+  });
+
+  it("GET /api/stats always includes totalContributors, readyCount, readyPercent", async () => {
+    vi.mocked(getDashboardStats).mockResolvedValue({
+      totalContributors: 5,
+      readyCount: 3,
+      readyPercent: 60,
+    });
+    const json = await (await statsGet()).json();
+    expect(json).toHaveProperty("totalContributors");
+    expect(json).toHaveProperty("readyCount");
+    expect(json).toHaveProperty("readyPercent");
+  });
+});

--- a/tests/unit/__snapshots__/csv.test.ts.snap
+++ b/tests/unit/__snapshots__/csv.test.ts.snap
@@ -1,13 +1,13 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`CSV helpers > builds CSV with headers and rows 1`] = `
-"name","value"
+""name","value"
 "alice","100"
-"bob","200"
+"bob","200""
 `;
 
 exports[`JSON helpers > builds JSON from headers and rows 1`] = `
-[
+"[
   {
     "name": "alice",
     "value": 100
@@ -16,5 +16,5 @@ exports[`JSON helpers > builds JSON from headers and rows 1`] = `
     "name": "bob",
     "value": 200
   }
-]
+]"
 `;

--- a/tests/unit/sentry.test.ts
+++ b/tests/unit/sentry.test.ts
@@ -1,0 +1,240 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  captureException,
+  captureExceptionWithScope,
+  captureMessage,
+  flushSentry,
+  isSentryEnabled,
+  setSentryUser,
+  _resetSentryClient,
+} from "@/lib/sentry";
+
+const ORIGINAL_ENV = process.env;
+
+beforeEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+  _resetSentryClient();
+});
+
+afterEach(() => {
+  process.env = ORIGINAL_ENV;
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+  _resetSentryClient();
+});
+
+// ---------------------------------------------------------------------------
+// No-op behaviour (no DSN configured)
+// ---------------------------------------------------------------------------
+describe("sentry helpers — no DSN (no-op mode)", () => {
+  beforeEach(() => {
+    delete process.env.NEXT_PUBLIC_SENTRY_DSN;
+    _resetSentryClient();
+  });
+
+  it("isSentryEnabled returns false when DSN is absent", () => {
+    expect(isSentryEnabled()).toBe(false);
+  });
+
+  it("captureException returns empty string and does not throw", () => {
+    const id = captureException(new Error("boom"));
+    expect(id).toBe("");
+  });
+
+  it("captureException accepts a non-Error value without throwing", () => {
+    expect(() => captureException("string error")).not.toThrow();
+    expect(() => captureException(null)).not.toThrow();
+    expect(() => captureException(undefined)).not.toThrow();
+    expect(() => captureException(42)).not.toThrow();
+  });
+
+  it("captureException accepts context without throwing", () => {
+    const id = captureException(new Error("ctx"), { route: "/api/test", userId: "u_1" });
+    expect(id).toBe("");
+  });
+
+  it("captureMessage returns empty string and does not throw", () => {
+    const id = captureMessage("hello sentry");
+    expect(id).toBe("");
+  });
+
+  it("captureMessage accepts explicit level", () => {
+    expect(() => captureMessage("warn msg", "warning")).not.toThrow();
+    expect(() => captureMessage("err msg", "error")).not.toThrow();
+    expect(() => captureMessage("debug msg", "debug")).not.toThrow();
+    expect(() => captureMessage("fatal msg", "fatal")).not.toThrow();
+  });
+
+  it("captureExceptionWithScope returns empty string and does not throw", () => {
+    const id = captureExceptionWithScope(
+      new Error("scoped"),
+      { id: "u_123", username: "alice" },
+      { route: "/api/register" },
+      "error"
+    );
+    expect(id).toBe("");
+  });
+
+  it("captureExceptionWithScope handles null user", () => {
+    expect(() =>
+      captureExceptionWithScope(new Error("anon"), null, {}, "warning")
+    ).not.toThrow();
+  });
+
+  it("setSentryUser does not throw", () => {
+    expect(() => setSentryUser({ id: "u_1", username: "bob" })).not.toThrow();
+    expect(() => setSentryUser(null)).not.toThrow();
+  });
+
+  it("flushSentry resolves to true", async () => {
+    await expect(flushSentry()).resolves.toBe(true);
+    await expect(flushSentry(500)).resolves.toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DSN configured but @sentry/nextjs not installed (graceful fallback)
+// ---------------------------------------------------------------------------
+describe("sentry helpers — DSN set but package unavailable (graceful fallback)", () => {
+  // The real @sentry/nextjs is not installed in this project (it's an optional
+  // peer dep). With NEXT_PUBLIC_SENTRY_DSN set and a missing package the
+  // try/catch in resolveClient() must catch the require error and silently
+  // degrade to the no-op stub, so all helpers still work without throwing.
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_SENTRY_DSN = "https://fake@sentry.io/123";
+    _resetSentryClient();
+  });
+
+  afterEach(() => {
+    _resetSentryClient();
+  });
+
+  it("falls back to no-op when @sentry/nextjs cannot be required", () => {
+    // @sentry/nextjs is not installed → require() throws → resolveClient()
+    // catches and returns noopClient → captureException must not re-throw.
+    expect(() => captureException(new Error("sentry-fallback"))).not.toThrow();
+  });
+
+  it("captureException returns empty string in fallback mode", () => {
+    const id = captureException(new Error("fallback-id"));
+    expect(id).toBe("");
+  });
+
+  it("captureMessage returns empty string in fallback mode", () => {
+    const id = captureMessage("fallback message");
+    expect(id).toBe("");
+  });
+
+  it("flushSentry resolves to true in fallback mode", async () => {
+    await expect(flushSentry()).resolves.toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DSN configured and @sentry/nextjs is available (happy path)
+// ---------------------------------------------------------------------------
+describe("sentry helpers — DSN set and SDK available", () => {
+  const mockCaptureException = vi.fn().mockReturnValue("event-id-1");
+  const mockCaptureMessage = vi.fn().mockReturnValue("event-id-2");
+  const mockWithScope = vi.fn((cb: (scope: unknown) => void) => {
+    cb({
+      setTag: vi.fn(),
+      setUser: vi.fn(),
+      setExtra: vi.fn(),
+      setLevel: vi.fn(),
+    });
+  });
+  const mockSetUser = vi.fn();
+  const mockFlush = vi.fn().mockResolvedValue(true);
+
+  const fakeSentryModule = {
+    captureException: mockCaptureException,
+    captureMessage: mockCaptureMessage,
+    withScope: mockWithScope,
+    setUser: mockSetUser,
+    flush: mockFlush,
+  };
+
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_SENTRY_DSN = "https://key@sentry.io/456";
+    _resetSentryClient();
+    // Patch the require call inside sentry.ts by overriding the module
+    // resolution through require.cache so the next require('@sentry/nextjs')
+    // returns our fake module.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const Module = require("module") as {
+      _resolveFilename: (id: string, parent: unknown) => string;
+    };
+    const resolvedPath = (() => {
+      try {
+        return Module._resolveFilename("@sentry/nextjs", null);
+      } catch {
+        return null;
+      }
+    })();
+
+    if (resolvedPath) {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      (require as NodeRequire & { cache: Record<string, unknown> }).cache[
+        resolvedPath
+      ] = {
+        id: resolvedPath,
+        filename: resolvedPath,
+        loaded: true,
+        exports: fakeSentryModule,
+        // minimal NodeModule shape:
+        children: [],
+        paths: [],
+        parent: null,
+        require,
+        path: resolvedPath,
+      } as unknown as NodeModule;
+    }
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    _resetSentryClient();
+  });
+
+  it("isSentryEnabled returns true when DSN is present", () => {
+    expect(isSentryEnabled()).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Edge cases
+// ---------------------------------------------------------------------------
+describe("sentry helpers — edge cases", () => {
+  it("isSentryEnabled returns false for blank-string DSN", () => {
+    process.env.NEXT_PUBLIC_SENTRY_DSN = "   ";
+    _resetSentryClient();
+    expect(isSentryEnabled()).toBe(false);
+  });
+
+  it("captureExceptionWithScope uses default level of 'error'", () => {
+    delete process.env.NEXT_PUBLIC_SENTRY_DSN;
+    _resetSentryClient();
+    // In no-op mode this just validates no throw; level default is exercised.
+    expect(() =>
+      captureExceptionWithScope(new Error("default level"), { id: "u_1" })
+    ).not.toThrow();
+  });
+
+  it("captureExceptionWithScope handles empty tags object", () => {
+    delete process.env.NEXT_PUBLIC_SENTRY_DSN;
+    _resetSentryClient();
+    expect(() =>
+      captureExceptionWithScope(new Error("no tags"), null, {})
+    ).not.toThrow();
+  });
+
+  it("setSentryUser accepts partial user objects", () => {
+    delete process.env.NEXT_PUBLIC_SENTRY_DSN;
+    _resetSentryClient();
+    expect(() => setSentryUser({ id: "u_1" })).not.toThrow();
+    expect(() => setSentryUser({ username: "alice" })).not.toThrow();
+    expect(() => setSentryUser({})).not.toThrow();
+  });
+});

--- a/tests/unit/stale-export.test.ts
+++ b/tests/unit/stale-export.test.ts
@@ -12,8 +12,11 @@ function makeRow(lastCheckedAt: string | null): ContributorRow {
     githubUsername: "test",
     stellarAddress: "GBSX",
     trustlineReady: true,
+    trustlineAuthorized: true,
+    verified: true,
     funded: true,
     xlmBalance: "2",
+    spendableXlmBalance: "1.5",
     lastCheckedAt,
     readiness: "ready",
   };

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,17 +1,3 @@
-import { defineConfig } from "vitest/config";
-import path from "node:path";
-
-export default defineConfig({
-  test: {
-    environment: "node",
-    globals: true,
-  },
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./src"),
-      "server-only": path.resolve(__dirname, "./tests/mocks/server-only.ts"),
-    },
-  },
 import path from "node:path";
 
 import { defineConfig } from "vitest/config";


### PR DESCRIPTION

Closes #34 
Closes #45 
Closes #48 
Closes #49

#49 — Sentry error tracking
- src/lib/sentry.ts: thin wrapper (captureException, captureMessage, captureExceptionWithScope, setSentryUser, flushSentry, isSentryEnabled) degrades to no-op when NEXT_PUBLIC_SENTRY_DSN is absent
- tests/unit/sentry.test.ts: 19 tests covering no-op, fallback, all helpers, edge cases
- docs/SENTRY.md: full setup guide, env vars, usage examples, instrumented routes, source maps, FAQ

#48 — /api/health probe
- src/app/api/health/route.ts: public GET endpoint, always 200, reports status ok/degraded/error; DB ping + CSV staleness check; no PII in response
- tests/api/health.test.ts: 11 tests

#34 — low_reserve filter split in /api/contributors
- GET /api/contributors now accepts ?readiness=ready|low_reserve|not_ready
- returns total, filtered, readiness fields; 400 for invalid values
- tests/api/contributors.test.ts: expanded to 13 tests covering all filter values, auth, CSRF

#45 — API integration tests (auth, roles, tokens)
- tests/api/integration-auth.test.ts: 16 tests for /api/register
- tests/api/integration-maintainer.test.ts: 20 tests for contributors, single recheck, audit log
- tests/api/integration-tokens-edge.test.ts: 19 tests for check, stats, health, rate limiting, token edge cases, response contracts

Fixes (pre-existing corruptions):
- vitest.config.ts: two configs were concatenated; restored canonical
- src/lib/horizon.ts: two versions were concatenated; restored canonical
- tests/api/check.test.ts: two versions were concatenated; restored
- src/app/dashboard/page.tsx: duplicate onExport prop + unused interface
- tests/unit/stale-export.test.ts: ContributorRow missing required fields
- tests/unit/__snapshots__/csv.test.ts.snap: updated for new vitest config

All 234 tests pass. Lint clean. Typecheck clea