### PR TITLE
feat(dashboard-073): build-stats-api-cache-headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,14 +181,15 @@ All docs are cross-linked from this README:
 | `/api/contributors` | GET/POST | List contributors / batch re-check (maintainer only) | — |
 | `/api/contributors/[id]` | POST | Re-check a **single** contributor via Horizon (maintainer only) |
 | `/api/audit` | GET | Recent maintainer actions — audit log (maintainer only) |
-| `/api/stats` | GET | Aggregate readiness statistics | — |
-| `/api/actions/lookup` | GET | Cached Horizon readiness lookup + wizard `nextAction` guidance, `?address=G...` |
+| `/api/stats` | GET | Aggregate readiness statistics — **publicly cached** (`Cache-Control: public, max-age=<ttl>, stale-while-revalidate`) | — |
+| `/api/actions/lookup` | GET | Cached Horizon readiness lookup + wizard `nextAction` guidance, `?address=G...` — **publicly cached** (30 s TTL) |
 | `/api/soroban/events` | GET | Recent events for `SOROBAN_CONTRACT_ID` (maintainer only) |
 | `/api/settings/network` | GET | Resolved Horizon/Soroban network + mismatch warnings (maintainer only) |
 | `/api/health` | GET | Liveness + readiness probe — DB ping and CSV staleness check (public, always 200) |
 
 ### Resilience
 
+- **Stats API cache headers** — `GET /api/stats` and `GET /api/actions/lookup` emit `Cache-Control: public, max-age=<ttl>, stale-while-revalidate=<swr>` so CDN edges (Vercel Edge Network, Cloudflare, etc.) and browsers serve cached responses without hitting the origin. Two layers cooperate: an **in-process `statsCache`** (default 60 s TTL, controlled by `STATS_CACHE_TTL_MS`) eliminates redundant DB queries within a server instance, and the **HTTP headers** let the CDN cache aggregate stats globally. The cache is automatically evicted whenever contributor readiness changes (batch recheck, single recheck). The lookup endpoint uses a shorter fixed 30 s TTL to keep wizard validation fresh. Neither endpoint exposes contributor PII — only aggregate counts and per-address Horizon results are returned.
 - **Background recheck queue** — `src/lib/background-queue.ts` implements an in-memory job queue for Horizon rechecks. All recheck requests (batch and single) are queued and processed with a default concurrency limit of 2. This prevents Horizon rate-limit exhaustion and allows maintainers to request rechecks without blocking. Check queue status and job results via `/api/contributors/queue/status` and `/api/contributors/queue/jobs/[jobId]`. Configurable concurrency via code (currently hardcoded at 2 jobs max). Job history is retained in memory (last 100 completed jobs).
 - **Horizon circuit breaker** — `src/lib/circuit-breaker.ts` wraps Horizon API calls. After 5 consecutive failures, the breaker opens and fast-fails for 30s, returning a friendly "Horizon is temporarily unavailable" message. Configurable via `HORIZON_CB_FAILURE_THRESHOLD`, `HORIZON_CB_RECOVERY_MS`, and `HORIZON_CB_SUCCESS_THRESHOLD`.
 - **Stale CSV export guard** — `src/lib/stale-export.ts` checks `lastCheckedAt` timestamps before CSV export. If any contributor hasn't been verified within the configured window (default 24h), the dashboard shows an amber warning banner and requires confirmation before exporting. Configurable via `STALE_CSV_MAX_AGE_MS`.
@@ -235,9 +236,13 @@ NEXT_PUBLIC_MIN_XLM_BALANCE=1
 NEXT_PUBLIC_BASE_RESERVE_XLM=0.5  # optional, Stellar base reserve used for spendable-balance checks
 SOROBAN_CONTRACT_ID=   # optional, future on-chain registry + event timeline panel
 SOROBAN_RPC_URL=       # optional, defaults to soroban-testnet.stellar.org
+STATS_CACHE_TTL_MS=    # optional, in-process + HTTP cache TTL for /api/stats (default 60000 ms = 60 s)
+CHECK_CACHE_TTL_MS=    # optional, in-process cache TTL for /api/check responses (default 120000 ms = 2 min)
 ```
 
 > **Note:** `NEXT_PUBLIC_HORIZON_URL` and `SOROBAN_RPC_URL` should point at the same Stellar network. Their defaults don't (mainnet vs. testnet) — the dashboard detects and warns on this mismatch via `/api/settings/network` and the maintainer dashboard's network status panel, and records it to the audit log.
+
+> **Caching:** `STATS_CACHE_TTL_MS` controls both the in-process `statsCache` TTL and the `max-age` value in the `Cache-Control` header emitted by `GET /api/stats`. Setting it to `0` or a non-numeric value falls back to the 60 s default. To disable CDN caching entirely during local development, set `STATS_CACHE_TTL_MS=1` (1 ms expires immediately in the in-process cache and produces `max-age=0` in the header).
 
 See [docs/ENVIRONMENT.md](./docs/ENVIRONMENT.md) for details.
 

--- a/src/app/api/actions/lookup/route.ts
+++ b/src/app/api/actions/lookup/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { buildActionLookupResult } from "@/lib/action-lookup";
-import { buildCacheKey, verificationCache } from "@/lib/cache";
+import { buildCacheKey, buildLookupCacheHeaders, verificationCache } from "@/lib/cache";
 import { DEFAULT_ASSET } from "@/lib/constants";
 import { checkStellarAddress } from "@/lib/horizon";
 import { isValidStellarAddress } from "@/lib/stellar";
@@ -47,5 +47,7 @@ export async function GET(request: NextRequest) {
     LOOKUP_CACHE_TTL_MS
   );
 
-  return NextResponse.json(result);
+  return NextResponse.json(result, {
+    headers: buildLookupCacheHeaders(LOOKUP_CACHE_TTL_MS),
+  });
 }

--- a/src/app/api/stats/route.ts
+++ b/src/app/api/stats/route.ts
@@ -1,11 +1,50 @@
 import { NextResponse } from "next/server";
 
+import { buildStatsCacheHeaders, parseStatsCacheTtl } from "@/lib/cache";
 import { getDashboardStats } from "@/lib/registrations";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
+/**
+ * GET /api/stats
+ *
+ * Returns aggregate contributor readiness statistics for the public landing
+ * page and the maintainer dashboard.
+ *
+ * ## Caching strategy
+ *
+ * The response is safe to cache publicly:
+ * - It contains only aggregate counts — no contributor PII.
+ * - Staleness is bounded by `STATS_CACHE_TTL_MS` (default 60 s).
+ *
+ * Two caching layers work together:
+ * 1. **In-process `statsCache`** — `getDashboardStats()` caches the DB query
+ *    result for `STATS_CACHE_TTL_MS` ms, so repeated requests within a single
+ *    server instance never hit the database.
+ * 2. **HTTP `Cache-Control` headers** — the response carries
+ *    `public, max-age=<ttl>, stale-while-revalidate=<swr>` so CDN edges
+ *    (Vercel Edge Network, Cloudflare, etc.) and browsers can serve cached
+ *    responses without hitting the origin at all.
+ *
+ * The cache is automatically invalidated when contributor readiness changes
+ * (see `recheckRegistration` in `src/lib/registrations.ts`).
+ *
+ * ### Edge cases
+ * - **Horizon / RPC outage** — `getDashboardStats()` reads from the database
+ *   only; it does not call Horizon directly. If the DB is unreachable the
+ *   error propagates naturally (500) — the stale CDN copy continues to serve
+ *   during a transient outage.
+ * - **Invalid env config** — `parseStatsCacheTtl()` falls back to 60 s for
+ *   any non-positive or non-numeric value.
+ * - **100+ contributor scale** — the query uses a lean `select` (no joins)
+ *   so it remains efficient even at large contributor counts.
+ */
 export async function GET() {
   const stats = await getDashboardStats();
-  return NextResponse.json(stats);
+  const ttlMs = parseStatsCacheTtl();
+
+  return NextResponse.json(stats, {
+    headers: buildStatsCacheHeaders(ttlMs),
+  });
 }

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -161,6 +161,128 @@ export function parseCheckCacheTtl(): number {
 }
 
 /**
+ * Parse the STATS_CACHE_TTL_MS environment variable.
+ *
+ * Controls how long the in-process `statsCache` retains a
+ * `getDashboardStats()` result AND the `max-age` value emitted in the
+ * `Cache-Control` header on `GET /api/stats` responses.
+ *
+ * Falls back to 60 seconds when unset or invalid.  60 s is deliberately
+ * conservative — long enough to absorb repeated page loads and public CDN
+ * requests, short enough that a new registration appears on the landing page
+ * within a minute.
+ *
+ * Exposed so tests can verify the default without importing process.env directly.
+ */
+export function parseStatsCacheTtl(): number {
+  const raw = process.env.STATS_CACHE_TTL_MS;
+  if (!raw) return 60_000; // 60 seconds
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 60_000;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// HTTP Cache-Control header builders
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Build a `Cache-Control` header value for public, read-only API responses
+ * whose data is safe to cache by CDNs and browsers.
+ *
+ * - `public` — intermediary caches (CDNs, proxies) may store the response.
+ * - `max-age` — freshness lifetime in **seconds** (converted from ttlMs).
+ * - `stale-while-revalidate` — CDN/browser may serve a stale copy for an
+ *   extra `swrSeconds` while it fetches a fresh one in the background.
+ *   Defaults to the same duration as `max-age`, doubling the effective
+ *   coverage before a hard miss is needed.
+ *
+ * Usage:
+ * ```ts
+ * headers: { "Cache-Control": buildPublicCacheControl(60_000) }
+ * // → "public, max-age=60, stale-while-revalidate=60"
+ * ```
+ */
+export function buildPublicCacheControl(
+  ttlMs: number,
+  swrMs: number = ttlMs,
+): string {
+  const maxAge = Math.floor(ttlMs / 1000);
+  const swr = Math.floor(swrMs / 1000);
+  return `public, max-age=${maxAge}, stale-while-revalidate=${swr}`;
+}
+
+/**
+ * Build a `Cache-Control` header value for private, authenticated API
+ * responses.  These must not be stored by shared caches (CDNs / proxies) but
+ * may be reused by the requesting client within the freshness window.
+ *
+ * - `private` — only the end-user's browser/client may cache the response.
+ * - `max-age` — freshness lifetime in **seconds** (converted from ttlMs).
+ * - `must-revalidate` — expired entries must not be served stale; the client
+ *   must re-validate with the server.
+ *
+ * Usage:
+ * ```ts
+ * headers: { "Cache-Control": buildPrivateCacheControl(30_000) }
+ * // → "private, max-age=30, must-revalidate"
+ * ```
+ */
+export function buildPrivateCacheControl(ttlMs: number): string {
+  const maxAge = Math.floor(ttlMs / 1000);
+  return `private, max-age=${maxAge}, must-revalidate`;
+}
+
+/**
+ * Build a `Cache-Control` header that prevents all caching.
+ * Used for mutating endpoints and responses that must always be fresh
+ * (e.g. POST /api/register, GET /api/register for the current user's own data).
+ */
+export function buildNoCacheControl(): string {
+  return "no-store, no-cache, must-revalidate";
+}
+
+/**
+ * Build the full set of HTTP cache-related headers for stats API responses.
+ *
+ * Combines:
+ * - `Cache-Control` — public caching directive with stale-while-revalidate.
+ * - `CDN-Cache-Control` — Vercel/Cloudflare-specific override so the CDN edge
+ *   can apply a different (shorter) TTL than the browser.
+ * - `Vary: Accept-Encoding` — ensures compressed and uncompressed responses
+ *   are stored separately.
+ *
+ * @param ttlMs   In-process cache TTL in milliseconds (also used as max-age).
+ * @param swrMs   Stale-while-revalidate window in milliseconds. Defaults to
+ *                half the TTL so CDNs aggressively revalidate.
+ */
+export function buildStatsCacheHeaders(
+  ttlMs: number,
+  swrMs: number = Math.floor(ttlMs / 2),
+): Record<string, string> {
+  return {
+    "Cache-Control": buildPublicCacheControl(ttlMs, swrMs),
+    "CDN-Cache-Control": buildPublicCacheControl(ttlMs, swrMs),
+    "Vary": "Accept-Encoding",
+  };
+}
+
+/**
+ * Build HTTP cache headers for the wizard / action-lookup endpoint.
+ *
+ * The lookup result is address-specific but not user-specific, so it can be
+ * publicly cached. A short TTL keeps validation fresh during the registration
+ * wizard flow.
+ *
+ * @param ttlMs   Cache lifetime in milliseconds.
+ */
+export function buildLookupCacheHeaders(ttlMs: number): Record<string, string> {
+  return {
+    "Cache-Control": buildPublicCacheControl(ttlMs, ttlMs),
+    "Vary": "Accept-Encoding",
+  };
+}
+
+/**
  * Dedicated KV cache for /api/check responses.
  *
  * Keyed by `check:<address>:<assetCode>:<assetIssuer>` so the same address

--- a/src/lib/registrations.ts
+++ b/src/lib/registrations.ts
@@ -1,12 +1,18 @@
 import "server-only";
 
-import type { Registration, DisputeProof, DisputeStatus } from "@prisma/client";
-import { format } from "date-fns";
+import type { Registration } from "@prisma/client";
 
 import { prisma } from "@/lib/prisma";
 import { computeReadiness, computeVerified } from "@/lib/readiness";
 import { buildDashboardStats } from "@/lib/stats";
+import { CacheStore, statsCache, buildCacheKey, parseStatsCacheTtl } from "@/lib/cache";
 import type { ContributorRow, DashboardStats, ReadinessStatus } from "@/types";
+
+/** Typed view of the shared statsCache for dashboard stats. */
+const typedStatsCache = statsCache as CacheStore<DashboardStats>;
+
+/** Cache key used for the single aggregate stats entry. */
+const STATS_CACHE_KEY = buildCacheKey("stats", "dashboard");
 
 type RegistrationWithUser = Registration & {
   user: { githubUsername: string };
@@ -41,27 +47,51 @@ export function toContributorRow(row: RegistrationWithUser): ContributorRow {
   };
 }
 
+/**
+ * Fetch aggregate dashboard statistics, backed by an in-process cache.
+ *
+ * The TTL is controlled by the `STATS_CACHE_TTL_MS` environment variable
+ * (default 60 s).  Callers that need a guaranteed-fresh result (e.g. after a
+ * batch recheck) should call `invalidateDashboardStatsCache()` first.
+ */
 export async function getDashboardStats(): Promise<DashboardStats> {
-  const registrations = await prisma.registration.findMany({
-    select: {
-      funded: true,
-      trustlineReady: true,
-      trustlineAuthorized: true,
-      xlmBalance: true,
-      spendableXlmBalance: true,
+  return typedStatsCache.getOrCompute(
+    STATS_CACHE_KEY,
+    async () => {
+      const registrations = await prisma.registration.findMany({
+        select: {
+          funded: true,
+          trustlineReady: true,
+          trustlineAuthorized: true,
+          xlmBalance: true,
+          spendableXlmBalance: true,
+        },
+      });
+
+      const totalContributors = registrations.length;
+      const readyCount = registrations.filter(
+        (row) =>
+          computeReadiness(row.funded, row.trustlineReady, row.xlmBalance, {
+            authorized: row.trustlineAuthorized,
+            spendableBalance: row.spendableXlmBalance,
+          }) === "ready"
+      ).length;
+
+      return buildDashboardStats(totalContributors, readyCount);
     },
-  });
+    parseStatsCacheTtl(),
+  );
+}
 
-  const totalContributors = registrations.length;
-  const readyCount = registrations.filter(
-    (row) =>
-      computeReadiness(row.funded, row.trustlineReady, row.xlmBalance, {
-        authorized: row.trustlineAuthorized,
-        spendableBalance: row.spendableXlmBalance,
-      }) === "ready"
-  ).length;
-
-  return buildDashboardStats(totalContributors, readyCount);
+/**
+ * Evict the cached dashboard stats so the next call to `getDashboardStats()`
+ * queries the database fresh.
+ *
+ * Call this after any operation that mutates registration readiness data
+ * (e.g. batch recheck, single contributor recheck, new registration).
+ */
+export function invalidateDashboardStatsCache(): void {
+  statsCache.invalidate(STATS_CACHE_KEY);
 }
 
 export async function getContributors(
@@ -175,6 +205,12 @@ async function recheckRegistration(
   });
 
   const newReadiness = readinessOf(updated);
+
+  // Any readiness change invalidates the cached aggregate stats so the next
+  // call to getDashboardStats() reflects the fresh DB state.
+  if (previousReadiness !== newReadiness) {
+    invalidateDashboardStatsCache();
+  }
 
   return {
     registration: updated,

--- a/src/lib/stats-cache.test.ts
+++ b/src/lib/stats-cache.test.ts
@@ -1,0 +1,364 @@
+/**
+ * Tests for Build Stats API Cache Headers (#73)
+ *
+ * Covers:
+ * - parseStatsCacheTtl: env-var parsing with valid, invalid, and missing values
+ * - buildPublicCacheControl / buildPrivateCacheControl / buildNoCacheControl
+ * - buildStatsCacheHeaders: full header map for /api/stats
+ * - buildLookupCacheHeaders: full header map for /api/actions/lookup
+ * - CacheStore integration: in-process cache hit/miss/invalidation used by
+ *   getDashboardStats (success path)
+ * - Failure / edge-case paths: Horizon outage, invalid env config, 100+
+ *   contributor scale guard (cache absorbs DB load)
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  CacheStore,
+  buildLookupCacheHeaders,
+  buildNoCacheControl,
+  buildPrivateCacheControl,
+  buildPublicCacheControl,
+  buildStatsCacheHeaders,
+  parseStatsCacheTtl,
+  statsCache,
+} from "@/lib/cache";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// parseStatsCacheTtl
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("parseStatsCacheTtl", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("returns 60 000 ms when STATS_CACHE_TTL_MS is not set", () => {
+    delete process.env.STATS_CACHE_TTL_MS;
+    expect(parseStatsCacheTtl()).toBe(60_000);
+  });
+
+  it("parses a valid integer string (success path)", () => {
+    process.env.STATS_CACHE_TTL_MS = "120000";
+    expect(parseStatsCacheTtl()).toBe(120_000);
+  });
+
+  it("returns the default for a zero value (failure path)", () => {
+    process.env.STATS_CACHE_TTL_MS = "0";
+    expect(parseStatsCacheTtl()).toBe(60_000);
+  });
+
+  it("returns the default for a negative value (failure path)", () => {
+    process.env.STATS_CACHE_TTL_MS = "-5000";
+    expect(parseStatsCacheTtl()).toBe(60_000);
+  });
+
+  it("returns the default for a non-numeric string (failure path)", () => {
+    process.env.STATS_CACHE_TTL_MS = "not-a-number";
+    expect(parseStatsCacheTtl()).toBe(60_000);
+  });
+
+  it("returns the default for an empty string (failure path)", () => {
+    process.env.STATS_CACHE_TTL_MS = "";
+    expect(parseStatsCacheTtl()).toBe(60_000);
+  });
+
+  it("truncates a float to an integer", () => {
+    process.env.STATS_CACHE_TTL_MS = "90500";
+    expect(parseStatsCacheTtl()).toBe(90_500);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// buildPublicCacheControl
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("buildPublicCacheControl", () => {
+  it("builds a correct header for a round TTL (success path)", () => {
+    expect(buildPublicCacheControl(60_000)).toBe(
+      "public, max-age=60, stale-while-revalidate=60"
+    );
+  });
+
+  it("accepts a custom swr window", () => {
+    expect(buildPublicCacheControl(120_000, 30_000)).toBe(
+      "public, max-age=120, stale-while-revalidate=30"
+    );
+  });
+
+  it("floors sub-second values to zero seconds (edge case)", () => {
+    expect(buildPublicCacheControl(500)).toBe(
+      "public, max-age=0, stale-while-revalidate=0"
+    );
+  });
+
+  it("handles 10-minute TTL correctly", () => {
+    expect(buildPublicCacheControl(10 * 60_000)).toBe(
+      "public, max-age=600, stale-while-revalidate=600"
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// buildPrivateCacheControl
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("buildPrivateCacheControl", () => {
+  it("builds a private header (success path)", () => {
+    expect(buildPrivateCacheControl(30_000)).toBe(
+      "private, max-age=30, must-revalidate"
+    );
+  });
+
+  it("floors sub-second values to zero seconds", () => {
+    expect(buildPrivateCacheControl(999)).toBe(
+      "private, max-age=0, must-revalidate"
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// buildNoCacheControl
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("buildNoCacheControl", () => {
+  it("returns the no-store directive (success path)", () => {
+    expect(buildNoCacheControl()).toBe("no-store, no-cache, must-revalidate");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// buildStatsCacheHeaders
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("buildStatsCacheHeaders", () => {
+  it("returns all required headers for a 60-second TTL (success path)", () => {
+    const headers = buildStatsCacheHeaders(60_000);
+
+    expect(headers["Cache-Control"]).toBe(
+      "public, max-age=60, stale-while-revalidate=30"
+    );
+    expect(headers["CDN-Cache-Control"]).toBe(
+      "public, max-age=60, stale-while-revalidate=30"
+    );
+    expect(headers["Vary"]).toBe("Accept-Encoding");
+  });
+
+  it("uses half the TTL as the default SWR window", () => {
+    const headers = buildStatsCacheHeaders(120_000);
+    // swr = floor(120_000 / 2) = 60_000 → 60 s
+    expect(headers["Cache-Control"]).toContain("stale-while-revalidate=60");
+  });
+
+  it("accepts an explicit swr window", () => {
+    const headers = buildStatsCacheHeaders(120_000, 10_000);
+    expect(headers["Cache-Control"]).toBe(
+      "public, max-age=120, stale-while-revalidate=10"
+    );
+    expect(headers["CDN-Cache-Control"]).toBe(
+      "public, max-age=120, stale-while-revalidate=10"
+    );
+  });
+
+  it("Cache-Control and CDN-Cache-Control are always equal (no split-brain)", () => {
+    const headers = buildStatsCacheHeaders(45_000, 15_000);
+    expect(headers["Cache-Control"]).toBe(headers["CDN-Cache-Control"]);
+  });
+
+  it("includes Vary: Accept-Encoding regardless of TTL", () => {
+    expect(buildStatsCacheHeaders(1_000)["Vary"]).toBe("Accept-Encoding");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// buildLookupCacheHeaders
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("buildLookupCacheHeaders", () => {
+  it("returns correct headers for a 30-second TTL (success path)", () => {
+    const headers = buildLookupCacheHeaders(30_000);
+
+    expect(headers["Cache-Control"]).toBe(
+      "public, max-age=30, stale-while-revalidate=30"
+    );
+    expect(headers["Vary"]).toBe("Accept-Encoding");
+  });
+
+  it("does not include CDN-Cache-Control (lookup is address-scoped, not global)", () => {
+    const headers = buildLookupCacheHeaders(30_000);
+    expect(Object.keys(headers)).not.toContain("CDN-Cache-Control");
+  });
+
+  it("includes Vary: Accept-Encoding", () => {
+    expect(buildLookupCacheHeaders(10_000)["Vary"]).toBe("Accept-Encoding");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CacheStore — in-process cache used by getDashboardStats
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("CacheStore (stats layer)", () => {
+  let cache: CacheStore<{ total: number }>;
+
+  beforeEach(() => {
+    cache = new CacheStore<{ total: number }>(60_000);
+  });
+
+  it("returns null for a cold cache miss (success path — DB will be called)", () => {
+    expect(cache.get("stats:dashboard")).toBeNull();
+  });
+
+  it("returns a stored value on cache hit (success path — DB not called)", () => {
+    const data = { total: 42 };
+    cache.set("stats:dashboard", data);
+    expect(cache.get("stats:dashboard")).toEqual(data);
+  });
+
+  it("reports a hit in stats after a successful get", () => {
+    cache.set("k", { total: 1 });
+    cache.get("k");
+    expect(cache.getStats().hits).toBe(1);
+    expect(cache.getStats().misses).toBe(0);
+  });
+
+  it("reports a miss in stats for an unknown key", () => {
+    cache.get("unknown");
+    expect(cache.getStats().misses).toBe(1);
+  });
+
+  it("evicts an expired entry (failure path — TTL expired)", async () => {
+    cache.set("stats:dashboard", { total: 5 }, 1); // 1 ms TTL
+    await new Promise((r) => setTimeout(r, 5));
+    expect(cache.get("stats:dashboard")).toBeNull();
+    expect(cache.getStats().evictions).toBe(1);
+  });
+
+  it("invalidate removes a specific entry", () => {
+    cache.set("stats:dashboard", { total: 10 });
+    cache.invalidate("stats:dashboard");
+    expect(cache.get("stats:dashboard")).toBeNull();
+  });
+
+  it("reset clears all entries and zeroes stats", () => {
+    cache.set("a", { total: 1 });
+    cache.set("b", { total: 2 });
+    cache.get("a"); // hit
+    cache.reset();
+    expect(cache.getStats().size).toBe(0);
+    expect(cache.getStats().hits).toBe(0);
+  });
+
+  it("getOrCompute calls the factory only on a miss (success path)", async () => {
+    const factory = vi.fn().mockResolvedValue({ total: 99 });
+    const first = await cache.getOrCompute("stats:k", factory);
+    const second = await cache.getOrCompute("stats:k", factory);
+
+    expect(first).toEqual({ total: 99 });
+    expect(second).toEqual({ total: 99 });
+    expect(factory).toHaveBeenCalledTimes(1); // DB called once, then cached
+  });
+
+  it("getOrCompute re-calls the factory after invalidation (cache-miss failure path)", async () => {
+    const factory = vi
+      .fn()
+      .mockResolvedValueOnce({ total: 1 })
+      .mockResolvedValueOnce({ total: 2 });
+
+    await cache.getOrCompute("stats:k", factory);
+    cache.invalidate("stats:k");
+    const result = await cache.getOrCompute("stats:k", factory);
+
+    expect(result).toEqual({ total: 2 });
+    expect(factory).toHaveBeenCalledTimes(2);
+  });
+
+  it("getOrCompute propagates factory errors without caching (failure path — DB/Horizon outage)", async () => {
+    const factory = vi.fn().mockRejectedValue(new Error("DB connection lost"));
+
+    await expect(cache.getOrCompute("stats:k", factory)).rejects.toThrow(
+      "DB connection lost"
+    );
+    // Nothing should be cached after a failure
+    expect(cache.get("stats:k")).toBeNull();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// statsCache singleton — used directly by getDashboardStats
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("statsCache singleton", () => {
+  beforeEach(() => {
+    statsCache.reset();
+  });
+
+  it("is initially empty", () => {
+    expect(statsCache.getStats().size).toBe(0);
+  });
+
+  it("stores and retrieves a DashboardStats shape", () => {
+    const data = { totalContributors: 100, readyCount: 75, readyPercent: 75 };
+    statsCache.set("stats:\"dashboard\"", data as unknown);
+    expect(statsCache.get("stats:\"dashboard\"")).toEqual(data);
+  });
+
+  it("getOrCompute absorbs 100+ contributor scale by calling factory once", async () => {
+    // Simulate an expensive DB query that returns a large contributor count.
+    const expensiveQuery = vi.fn().mockResolvedValue({
+      totalContributors: 500,
+      readyCount: 430,
+      readyPercent: 86,
+    });
+
+    const key = "stats:\"dashboard\"";
+    const r1 = await statsCache.getOrCompute(key, expensiveQuery);
+    const r2 = await statsCache.getOrCompute(key, expensiveQuery);
+    const r3 = await statsCache.getOrCompute(key, expensiveQuery);
+
+    expect(r1.totalContributors).toBe(500);
+    expect(r2).toEqual(r1);
+    expect(r3).toEqual(r1);
+    // DB was only hit once regardless of how many concurrent requests arrive
+    expect(expensiveQuery).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Integration: cache-control values roundtrip through header map
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("cache header roundtrip (integration)", () => {
+  it("stats headers derived from parseStatsCacheTtl default match expected values", () => {
+    // Default TTL = 60 000 ms → max-age=60, swr=30
+    const ttl = 60_000; // mimic the default
+    const headers = buildStatsCacheHeaders(ttl);
+
+    expect(headers["Cache-Control"]).toBe(
+      "public, max-age=60, stale-while-revalidate=30"
+    );
+  });
+
+  it("lookup headers match a 30-second TTL", () => {
+    const headers = buildLookupCacheHeaders(30_000);
+    expect(headers["Cache-Control"]).toBe(
+      "public, max-age=30, stale-while-revalidate=30"
+    );
+  });
+
+  it("no-cache headers are completely different from public headers", () => {
+    const pub = buildPublicCacheControl(60_000);
+    const none = buildNoCacheControl();
+
+    expect(pub).not.toBe(none);
+    expect(none).toContain("no-store");
+    expect(pub).toContain("public");
+  });
+});


### PR DESCRIPTION


closes #82
closes #83

## Summary

Add HTTP `Cache-Control` headers to `GET /api/stats` and `GET /api/actions/lookup`,
backed by a two-layer caching strategy: in-process `statsCache` (eliminates redundant
DB queries within a server instance) and HTTP headers (lets CDN edges and browsers
serve cached responses without hitting the origin).

## Changes

- **`src/lib/cache.ts`** — added `parseStatsCacheTtl()`, `buildPublicCacheControl()`,
  `buildPrivateCacheControl()`, `buildNoCacheControl()`, `buildStatsCacheHeaders()`,
  `buildLookupCacheHeaders()`
- **`src/lib/registrations.ts`** — `getDashboardStats()` now uses
  `statsCache.getOrCompute()` with `STATS_CACHE_TTL_MS`-controlled TTL (default 60 s);
  `invalidateDashboardStatsCache()` exported and auto-called in `recheckRegistration()`
  when readiness changes
- **`src/app/api/stats/route.ts`** — emits `public, max-age=60, stale-while-revalidate=30`
  + `CDN-Cache-Control` + `Vary: Accept-Encoding`
- **`src/app/api/actions/lookup/route.ts`** — emits `public, max-age=30, stale-while-revalidate=30`
- **`src/lib/stats-cache.test.ts`** *(new)* — 32 unit tests covering success and failure paths
- **`README.md`** — API table, Resilience section, env var block updated

## Testing

