### PR TITLE
feat(dashboard-010): ship contract-to-Postgres sync job

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,3 +50,13 @@ SOROBAN_RPC_URL=
 # Defaults to 120000 (2 minutes). Set to a positive integer to override.
 # Transient Horizon errors are never cached regardless of this value.
 CHECK_CACHE_TTL_MS=
+
+# Optional: bearer token that authorizes a scheduler (e.g. Vercel Cron) to
+# trigger POST /api/contract-sync without a maintainer session. With this
+# unset, only maintainer sessions can trigger a sync.
+CRON_SECRET=
+
+# Optional: minimum time in milliseconds between /api/contract-sync runs.
+# Defaults to 60000 (1 minute). A trigger inside this window is skipped
+# rather than re-running Horizon checks for every registration.
+CONTRACT_SYNC_MIN_INTERVAL_MS=

--- a/README.md
+++ b/README.md
@@ -185,7 +185,13 @@ All docs are cross-linked from this README:
 | `/api/actions/lookup` | GET | Cached Horizon readiness lookup + wizard `nextAction` guidance, `?address=G...` |
 | `/api/soroban/events` | GET | Recent events for `SOROBAN_CONTRACT_ID` (maintainer only) |
 | `/api/settings/network` | GET | Resolved Horizon/Soroban network + mismatch warnings (maintainer only) |
-| `/api/health` | GET | Liveness + readiness probe — DB ping and CSV staleness check (public, always 200) |
+| `/api/health` | GET | Liveness + readiness probe — DB ping, CSV staleness, and contract-sync status (public, always 200) |
+| `/api/contract-sync` | GET/POST | GET: last sync result (public). POST: trigger a contract-to-Postgres sync (maintainer session or `CRON_SECRET`) |
+
+### Contract-to-Postgres sync job
+
+- **`src/lib/contract-sync.ts`** re-syncs Postgres registration state against Horizon-verified funded/trustline/balance state, intended to be driven by a scheduler (e.g. Vercel Cron) rather than a maintainer clicking "recheck all". Trigger with `POST /api/contract-sync` (maintainer session, or a scheduler presenting `Authorization: Bearer $CRON_SECRET`); read the last run via `GET /api/contract-sync` or the `contractSync` block of `/api/health`.
+- Rate-limited via `CONTRACT_SYNC_MIN_INTERVAL_MS` (default 60s) so a mis-configured scheduler can't fan out into repeated full-table Horizon sweeps, and never throws — Horizon/RPC outages and DB errors are captured in the result instead of raising a 500.
 
 ### Resilience
 

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -186,6 +186,17 @@ Soroban RPC endpoint used to fetch contract events for the timeline panel. Defau
 
 **Keep this on the same network as `NEXT_PUBLIC_HORIZON_URL` above.** The default here is testnet while the default Horizon URL is mainnet — see the network consistency note above and [Architecture — network hardening](./ARCHITECTURE.md#network-hardening) for how the mismatch is surfaced.
 
+### `CRON_SECRET`
+
+Bearer token that authorizes a scheduler (e.g. Vercel Cron) to trigger `POST /api/contract-sync` without a maintainer session. Send as `Authorization: Bearer $CRON_SECRET`.
+
+- **Optional.** With it unset, only maintainer sessions can trigger a sync — the endpoint never falls back to an open/unauthenticated trigger.
+- Generate the same way as `NEXTAUTH_SECRET`: `openssl rand -base64 32`
+
+### `CONTRACT_SYNC_MIN_INTERVAL_MS`
+
+Minimum time between `/api/contract-sync` runs; a trigger inside this window returns `{ status: "skipped" }` instead of re-running Horizon checks for every registration. Defaults to `60000` (1 minute).
+
 ---
 
 ## Vercel configuration

--- a/src/app/api/contract-sync/route.test.ts
+++ b/src/app/api/contract-sync/route.test.ts
@@ -1,0 +1,119 @@
+import { NextRequest } from "next/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/api-auth", () => ({
+  requireMaintainerSession: vi.fn(),
+}));
+
+vi.mock("@/lib/contract-sync", () => ({
+  syncContractToPostgres: vi.fn(),
+  getContractSyncHealth: vi.fn(),
+}));
+
+import { requireMaintainerSession } from "@/lib/api-auth";
+import {
+  getContractSyncHealth,
+  syncContractToPostgres,
+} from "@/lib/contract-sync";
+import { GET, POST } from "@/app/api/contract-sync/route";
+
+function post(headers: Record<string, string> = {}) {
+  return new NextRequest("http://localhost:3000/api/contract-sync", {
+    method: "POST",
+    headers: { host: "localhost:3000", ...headers },
+  });
+}
+
+describe("POST /api/contract-sync", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    delete process.env.CRON_SECRET;
+  });
+
+  it("returns 403 with no maintainer session and no scheduler secret", async () => {
+    vi.mocked(requireMaintainerSession).mockResolvedValue(null);
+
+    const res = await POST(post());
+
+    expect(res.status).toBe(403);
+    expect(syncContractToPostgres).not.toHaveBeenCalled();
+  });
+
+  it("allows a maintainer session to trigger a sync", async () => {
+    vi.mocked(requireMaintainerSession).mockResolvedValue({
+      user: { id: "u1", isMaintainer: true },
+    } as never);
+    vi.mocked(syncContractToPostgres).mockResolvedValue({
+      status: "ok",
+      startedAt: new Date().toISOString(),
+      durationMs: 5,
+    });
+
+    const res = await POST(post());
+
+    expect(res.status).toBe(200);
+    expect(syncContractToPostgres).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows a request bearing a valid CRON_SECRET even without a session", async () => {
+    process.env.CRON_SECRET = "s3cr3t";
+    vi.mocked(requireMaintainerSession).mockResolvedValue(null);
+    vi.mocked(syncContractToPostgres).mockResolvedValue({
+      status: "ok",
+      startedAt: new Date().toISOString(),
+      durationMs: 5,
+    });
+
+    const res = await POST(post({ authorization: "Bearer s3cr3t" }));
+
+    expect(res.status).toBe(200);
+  });
+
+  it("rejects an invalid CRON_SECRET", async () => {
+    process.env.CRON_SECRET = "s3cr3t";
+    vi.mocked(requireMaintainerSession).mockResolvedValue(null);
+
+    const res = await POST(post({ authorization: "Bearer wrong" }));
+
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 502 when the sync run reports an error", async () => {
+    vi.mocked(requireMaintainerSession).mockResolvedValue({
+      user: { id: "u1", isMaintainer: true },
+    } as never);
+    vi.mocked(syncContractToPostgres).mockResolvedValue({
+      status: "error",
+      startedAt: new Date().toISOString(),
+      durationMs: 5,
+      error: "Horizon RPC outage",
+    });
+
+    const res = await POST(post());
+
+    expect(res.status).toBe(502);
+    const json = await res.json();
+    expect(json.error).toBe("Horizon RPC outage");
+  });
+});
+
+describe("GET /api/contract-sync", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the last sync result without triggering a new run", async () => {
+    vi.mocked(getContractSyncHealth).mockReturnValue({
+      status: "ok",
+      startedAt: "2026-07-27T00:00:00.000Z",
+      durationMs: 12,
+    });
+
+    const res = await GET();
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.lastRun.status).toBe("ok");
+    expect(syncContractToPostgres).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/contract-sync/route.ts
+++ b/src/app/api/contract-sync/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { requireMaintainerSession } from "@/lib/api-auth";
+import {
+  getContractSyncHealth,
+  syncContractToPostgres,
+} from "@/lib/contract-sync";
+import { assertSameOrigin } from "@/lib/csrf";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * Authorizes scheduler-triggered requests (e.g. Vercel Cron) that carry no
+ * maintainer session. Requires `CRON_SECRET` to be configured — with it
+ * unset, only maintainers can trigger a sync.
+ */
+function isAuthorizedScheduler(request: NextRequest): boolean {
+  const secret = process.env.CRON_SECRET?.trim();
+  if (!secret) return false;
+  return request.headers.get("authorization") === `Bearer ${secret}`;
+}
+
+/**
+ * POST /api/contract-sync
+ *
+ * Triggers a contract-to-Postgres sync run. Callable by a maintainer session
+ * (manual trigger) or a scheduler presenting `CRON_SECRET` (automated runs).
+ * Always returns 200/502 with a result body — never throws — so a scheduler
+ * retry storm can't be caused by an unhandled exception here.
+ */
+export async function POST(request: NextRequest) {
+  const csrf = assertSameOrigin(request);
+  if (csrf) return csrf;
+
+  const session = await requireMaintainerSession();
+  if (!session && !isAuthorizedScheduler(request)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const result = await syncContractToPostgres();
+  return NextResponse.json(result, {
+    status: result.status === "error" ? 502 : 200,
+  });
+}
+
+/**
+ * GET /api/contract-sync
+ *
+ * Read-only status of the most recent sync run, for dashboards/monitoring.
+ * Unauthenticated (no contributor PII — same posture as `/api/health`).
+ */
+export async function GET() {
+  return NextResponse.json({ lastRun: getContractSyncHealth() });
+}

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 
+import { getContractSyncHealth } from "@/lib/contract-sync";
 import { prisma } from "@/lib/prisma";
 import { buildStalenessSummary } from "@/lib/stale-export";
 import { toContributorRow } from "@/lib/registrations";
@@ -20,6 +21,11 @@ export interface HealthResponse {
       totalCount: number;
       stalePercent: number;
       warning: string;
+    };
+    contractSync: {
+      status: HealthStatus;
+      lastRunAt: string | null;
+      lastError?: string;
     };
   };
   version: string;
@@ -106,12 +112,19 @@ export async function GET(): Promise<NextResponse<HealthResponse>> {
   }
 
   // ------------------------------------------------------------------
+  // Contract-to-Postgres sync job status
+  // ------------------------------------------------------------------
+  const lastSync = getContractSyncHealth();
+  const contractSyncStatus: HealthStatus =
+    lastSync?.status === "error" ? "degraded" : "ok";
+
+  // ------------------------------------------------------------------
   // Overall status
   // ------------------------------------------------------------------
   let overallStatus: HealthStatus = "ok";
   if (dbStatus === "error") {
     overallStatus = "error";
-  } else if (csvStatus === "degraded") {
+  } else if (csvStatus === "degraded" || contractSyncStatus === "degraded") {
     overallStatus = "degraded";
   }
 
@@ -127,6 +140,11 @@ export async function GET(): Promise<NextResponse<HealthResponse>> {
       csvStaleness: {
         status: csvStatus,
         ...csvSummary,
+      },
+      contractSync: {
+        status: contractSyncStatus,
+        lastRunAt: lastSync?.startedAt ?? null,
+        ...(lastSync?.error ? { lastError: lastSync.error } : {}),
       },
     },
     version,

--- a/src/lib/contract-sync.test.ts
+++ b/src/lib/contract-sync.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/registrations", () => ({
+  refreshAllContributors: vi.fn(),
+}));
+
+vi.mock("@/lib/audit", () => ({
+  recordAuditLog: vi.fn(),
+}));
+
+import { recordAuditLog } from "@/lib/audit";
+import { refreshAllContributors } from "@/lib/registrations";
+import {
+  getContractSyncHealth,
+  resetContractSyncState,
+  syncContractToPostgres,
+} from "@/lib/contract-sync";
+
+const successSummary = {
+  refreshed: 10,
+  changed: 2,
+  diffs: [],
+  errors: [],
+};
+
+describe("contract-sync", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetContractSyncState();
+    delete process.env.CONTRACT_SYNC_MIN_INTERVAL_MS;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("runs a sync, records an audit log, and updates health on success", async () => {
+    vi.mocked(refreshAllContributors).mockResolvedValue(successSummary);
+
+    const result = await syncContractToPostgres();
+
+    expect(result.status).toBe("ok");
+    expect(result.summary).toEqual(successSummary);
+    expect(recordAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "contract.sync" })
+    );
+    expect(getContractSyncHealth()).toEqual(result);
+  });
+
+  it("never throws when refreshAllContributors fails, and records the error", async () => {
+    vi.mocked(refreshAllContributors).mockRejectedValue(
+      new Error("Horizon RPC outage")
+    );
+
+    const result = await syncContractToPostgres();
+
+    expect(result.status).toBe("error");
+    expect(result.error).toBe("Horizon RPC outage");
+    expect(recordAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "contract.sync",
+        metadata: { error: "Horizon RPC outage" },
+      })
+    );
+    expect(getContractSyncHealth()?.status).toBe("error");
+  });
+
+  it("rate-limits back-to-back triggers instead of re-hitting Horizon", async () => {
+    process.env.CONTRACT_SYNC_MIN_INTERVAL_MS = "60000";
+    vi.mocked(refreshAllContributors).mockResolvedValue(successSummary);
+
+    const first = await syncContractToPostgres();
+    const second = await syncContractToPostgres();
+
+    expect(first.status).toBe("ok");
+    expect(second.status).toBe("skipped");
+    expect(refreshAllContributors).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/contract-sync.ts
+++ b/src/lib/contract-sync.ts
@@ -1,0 +1,109 @@
+import "server-only";
+
+import { recordAuditLog } from "@/lib/audit";
+import { StructuredLogger } from "@/lib/logger";
+import { refreshAllContributors, type RefreshAllSummary } from "@/lib/registrations";
+
+const logger = new StructuredLogger("contract-sync");
+
+export type ContractSyncStatus = "ok" | "error" | "skipped";
+
+export interface ContractSyncResult {
+  status: ContractSyncStatus;
+  startedAt: string;
+  durationMs: number;
+  summary?: RefreshAllSummary;
+  error?: string;
+}
+
+let lastRunAt: number | null = null;
+let lastResult: ContractSyncResult | null = null;
+
+function getMinIntervalMs(): number {
+  const parsed = Number.parseInt(
+    process.env.CONTRACT_SYNC_MIN_INTERVAL_MS ?? "60000",
+    10
+  );
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 60000;
+}
+
+/**
+ * Re-syncs Postgres registration state against Horizon-verified
+ * funded/trustline/balance state, so contributor data does not silently
+ * drift stale between maintainer-triggered rechecks — intended to be
+ * driven by a scheduler (e.g. Vercel Cron) rather than a person.
+ *
+ * Rate-limited (`CONTRACT_SYNC_MIN_INTERVAL_MS`) so an over-eager
+ * scheduler or retry storm can't fan out into repeated full-table Horizon
+ * sweeps. Never throws: Horizon/RPC outages and DB errors are caught and
+ * returned as a result so a cron trigger never surfaces a 500.
+ */
+export async function syncContractToPostgres(): Promise<ContractSyncResult> {
+  const now = Date.now();
+  const minIntervalMs = getMinIntervalMs();
+
+  if (lastRunAt !== null && now - lastRunAt < minIntervalMs) {
+    logger.info("sync_skipped_rate_limited", {
+      msSinceLastRun: now - lastRunAt,
+      minIntervalMs,
+    });
+    return {
+      status: "skipped",
+      startedAt: new Date(now).toISOString(),
+      durationMs: 0,
+    };
+  }
+
+  lastRunAt = now;
+  const startedAt = new Date(now).toISOString();
+  logger.info("sync_started", { startedAt });
+
+  try {
+    const summary = await refreshAllContributors();
+    const durationMs = Date.now() - now;
+
+    logger.info("sync_completed", {
+      refreshed: summary.refreshed,
+      changed: summary.changed,
+      errorCount: summary.errors.length,
+      durationMs,
+    });
+
+    await recordAuditLog({
+      action: "contract.sync",
+      metadata: {
+        refreshed: summary.refreshed,
+        changed: summary.changed,
+        errorCount: summary.errors.length,
+      },
+    });
+
+    lastResult = { status: "ok", startedAt, durationMs, summary };
+    return lastResult;
+  } catch (error) {
+    const durationMs = Date.now() - now;
+    const message =
+      error instanceof Error ? error.message : "Unknown sync error";
+
+    logger.error("sync_failed", { error: message, durationMs });
+
+    await recordAuditLog({
+      action: "contract.sync",
+      metadata: { error: message },
+    });
+
+    lastResult = { status: "error", startedAt, durationMs, error: message };
+    return lastResult;
+  }
+}
+
+/** Last sync outcome, for the health endpoint. Never triggers a new run. */
+export function getContractSyncHealth(): ContractSyncResult | null {
+  return lastResult;
+}
+
+/** Test-only: reset in-memory rate-limit/health state between test runs. */
+export function resetContractSyncState(): void {
+  lastRunAt = null;
+  lastResult = null;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -50,7 +50,8 @@ export type AuditAction =
   | "recheck.batch"
   | "registration.create"
   | "registration.update"
-  | "network_config_mismatch_detected";
+  | "network_config_mismatch_detected"
+  | "contract.sync";
 
 export interface AuditLogEntry {
   id: string;


### PR DESCRIPTION
## Summary
- New `src/lib/contract-sync.ts`: a scheduler-driven job (`syncContractToPostgres`) that re-syncs Postgres registration state against Horizon-verified funded/trustline/balance state, instead of relying solely on a maintainer manually clicking "recheck all".
- New `POST /api/contract-sync` to trigger a run — authorized by either a maintainer session or a scheduler presenting `Authorization: Bearer $CRON_SECRET` (e.g. Vercel Cron); `GET /api/contract-sync` reads the last result without triggering a new run.
- Rate-limited via `CONTRACT_SYNC_MIN_INTERVAL_MS` (default 60s) so a misconfigured/retrying scheduler can't fan out into repeated full-table Horizon sweeps.
- Never throws: Horizon/RPC outages and DB errors are caught and reported in the result + audit log (`contract.sync` action) instead of raising a 500.
- Surfaced in `/api/health` under a new `contractSync` check.
- Docs: README routes table + new "Contract-to-Postgres sync job" section, `docs/ENVIRONMENT.md` (`CRON_SECRET`, `CONTRACT_SYNC_MIN_INTERVAL_MS`), `.env.example`.

## Test plan
- [x] `npx vitest run src/lib/contract-sync.test.ts src/app/api/contract-sync/route.test.ts tests/api/health.test.ts` — 26/26 passing, covering success, Horizon/RPC-outage failure (never throws), and rate-limit skip paths, plus auth (maintainer session / valid & invalid `CRON_SECRET` / no auth → 403) on the route
- [x] Confirmed no new regressions vs. `main`'s pre-existing unrelated test failures

Closes #10