### PR TITLE
feat(dashboard-014): refactor registry mode feature flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,3 +50,9 @@ SOROBAN_RPC_URL=
 # Defaults to 120000 (2 minutes). Set to a positive integer to override.
 # Transient Horizon errors are never cached regardless of this value.
 CHECK_CACHE_TTL_MS=
+
+# Optional: "live" (default) or "synced". Reported as `registryMode` by the
+# contributor REST endpoints. Reads are identical either way — this only
+# signals whether a scheduled contract-sync job (vs. manual maintainer
+# rechecks) is expected to be keeping Postgres fresh.
+REGISTRY_MODE=

--- a/README.md
+++ b/README.md
@@ -178,7 +178,8 @@ All docs are cross-linked from this README:
 | `/api/auth/[...nextauth]` | GET/POST | NextAuth.js handlers |
 | `/api/check` | POST | Horizon validation `{ address, asset_code?, asset_issuer? }` | 10 req/min |
 | `/api/register` | GET/POST | Read/save contributor registration (authenticated) | — |
-| `/api/contributors` | GET/POST | List contributors / batch re-check (maintainer only) | — |
+| `/api/contributors` | GET/POST | List contributors / batch re-check (maintainer only). Response includes `registryMode` (`REGISTRY_MODE` env var) | — |
+| `/api/contributors/paginated` | GET | Cursor-paginated contributor list for infinite scroll (maintainer only). Also includes `registryMode` | — |
 | `/api/contributors/[id]` | POST | Re-check a **single** contributor via Horizon (maintainer only) |
 | `/api/audit` | GET | Recent maintainer actions — audit log (maintainer only) |
 | `/api/stats` | GET | Aggregate readiness statistics | — |

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -127,6 +127,17 @@ Every Stellar account locks up `baseReserve * (2 + subentry_count + num_sponsori
 
 ## Optional variables
 
+### `REGISTRY_MODE`
+
+Reported by the contributor REST endpoints (`/api/contributors`, `/api/contributors/paginated`) as `registryMode` in their response body, via `src/lib/registry-mode.ts`.
+
+| Value | Meaning |
+|-------|---------|
+| `live` (default) | Reads reflect whatever is currently persisted; maintainers are expected to trigger a Horizon recheck to refresh it. |
+| `synced` | Signals that a scheduled contract-to-Postgres sync job (see `CONTRACT_SYNC_MIN_INTERVAL_MS` above) is responsible for keeping registrations fresh. |
+
+Reads are identical in both modes — Postgres is always the source of truth. An unset or unrecognized value falls back to `live` rather than failing.
+
 ### `GITHUB_MAINTAINER_TEAM`
 
 GitHub team **slug** within `GITHUB_MAINTAINER_ORG`. When set, a user must belong to both the org **and** this team to be treated as a maintainer.

--- a/src/app/api/contributors/paginated/route.test.ts
+++ b/src/app/api/contributors/paginated/route.test.ts
@@ -1,0 +1,107 @@
+import { NextRequest } from "next/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/api-auth", () => ({
+  requireMaintainerSession: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    registration: {
+      count: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/registrations", () => ({
+  getContributorsPaginated: vi.fn(),
+}));
+
+import { requireMaintainerSession } from "@/lib/api-auth";
+import { prisma } from "@/lib/prisma";
+import { getContributorsPaginated } from "@/lib/registrations";
+import { GET } from "@/app/api/contributors/paginated/route";
+
+function get(url: string) {
+  return new NextRequest(url, {
+    method: "GET",
+    headers: { host: "localhost:3000" },
+  });
+}
+
+describe("GET /api/contributors/paginated", () => {
+  beforeEach(() => {
+    vi.mocked(requireMaintainerSession).mockResolvedValue({
+      user: { id: "u-1", isMaintainer: true },
+    } as never);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 403 without a maintainer session", async () => {
+    vi.mocked(requireMaintainerSession).mockResolvedValue(null);
+
+    const res = await GET(
+      get("http://localhost:3000/api/contributors/paginated")
+    );
+
+    expect(res.status).toBe(403);
+    expect(getContributorsPaginated).not.toHaveBeenCalled();
+  });
+
+  it("delegates cursor pagination to getContributorsPaginated with defaults", async () => {
+    vi.mocked(getContributorsPaginated).mockResolvedValue({
+      contributors: [],
+      nextCursor: null,
+      hasMore: false,
+    });
+    vi.mocked(prisma.registration.count).mockResolvedValue(0);
+
+    const res = await GET(
+      get("http://localhost:3000/api/contributors/paginated")
+    );
+
+    expect(res.status).toBe(200);
+    expect(getContributorsPaginated).toHaveBeenCalledWith(undefined, 25);
+    const json = await res.json();
+    expect(json.registryMode).toBe("live");
+  });
+
+  it("passes the requested limit and cursor straight through", async () => {
+    vi.mocked(getContributorsPaginated).mockResolvedValue({
+      contributors: [],
+      nextCursor: "opaque-cursor",
+      hasMore: true,
+    });
+    vi.mocked(prisma.registration.count).mockResolvedValue(42);
+
+    const res = await GET(
+      get(
+        "http://localhost:3000/api/contributors/paginated?limit=10&cursor=abc123"
+      )
+    );
+
+    expect(getContributorsPaginated).toHaveBeenCalledWith("abc123", 10);
+    const json = await res.json();
+    expect(json.total).toBe(42);
+    expect(json.hasMore).toBe(true);
+    expect(json.nextCursor).toBe("opaque-cursor");
+  });
+
+  it("ignores an out-of-range limit and falls back to the default", async () => {
+    vi.mocked(getContributorsPaginated).mockResolvedValue({
+      contributors: [],
+      nextCursor: null,
+      hasMore: false,
+    });
+    vi.mocked(prisma.registration.count).mockResolvedValue(0);
+
+    await GET(
+      get("http://localhost:3000/api/contributors/paginated?limit=500")
+    );
+
+    expect(getContributorsPaginated).toHaveBeenCalledWith(undefined, 25);
+  });
+});

--- a/src/app/api/contributors/paginated/route.ts
+++ b/src/app/api/contributors/paginated/route.ts
@@ -1,7 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireMaintainerSession } from "@/lib/api-auth";
 import { prisma } from "@/lib/prisma";
-import { toContributorRow } from "@/lib/registrations";
+import { getRegistryMode } from "@/lib/registry-mode";
+import { getContributorsPaginated } from "@/lib/registrations";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -13,6 +14,10 @@ export const dynamic = "force-dynamic";
  * Query params:
  * - limit: number of items per page (default: 25, max: 100)
  * - cursor: cursor from previous page's response
+ *
+ * Delegates to `getContributorsPaginated` (src/lib/registrations.ts) — the
+ * same cursor-pagination logic already used and tested elsewhere — rather
+ * than re-implementing cursor handling against Prisma directly here.
  */
 export async function GET(request: NextRequest) {
   const session = await requireMaintainerSession();
@@ -22,7 +27,7 @@ export async function GET(request: NextRequest) {
 
   const searchParams = request.nextUrl.searchParams;
   const limitParam = searchParams.get("limit");
-  const cursor = searchParams.get("cursor");
+  const cursor = searchParams.get("cursor") ?? undefined;
 
   let limit = 25;
   if (limitParam) {
@@ -32,30 +37,16 @@ export async function GET(request: NextRequest) {
     }
   }
 
-  const registrations = await prisma.registration.findMany({
-    include: {
-      user: {
-        select: { githubUsername: true },
-      },
-    },
-    orderBy: { updatedAt: "desc" },
-    take: limit + 1,
-    ...(cursor && {
-      cursor: { id: cursor },
-      skip: 1,
-    }),
-  });
-
-  const hasMore = registrations.length > limit;
-  const items = hasMore ? registrations.slice(0, limit) : registrations;
-  const nextCursor = hasMore ? items[items.length - 1]?.id : undefined;
-
-  const contributors = items.map(toContributorRow);
+  const [{ contributors, nextCursor, hasMore }, total] = await Promise.all([
+    getContributorsPaginated(cursor, limit),
+    prisma.registration.count(),
+  ]);
 
   return NextResponse.json({
     contributors,
-    total: await prisma.registration.count(),
+    total,
     hasMore,
-    nextCursor,
+    nextCursor: nextCursor ?? undefined,
+    registryMode: getRegistryMode(),
   });
 }

--- a/src/app/api/contributors/route.ts
+++ b/src/app/api/contributors/route.ts
@@ -1,15 +1,22 @@
 import { NextRequest, NextResponse } from "next/server";
 
-import { requireMaintainerSession } from "@/lib/api-auth";
+import { refreshMaintainerSession, requireMaintainerSession } from "@/lib/api-auth";
 import { recordAuditLog } from "@/lib/audit";
 import { assertSameOrigin } from "@/lib/csrf";
+import { getRegistryMode } from "@/lib/registry-mode";
 import { getContributors, refreshAllContributors } from "@/lib/registrations";
 import type { ReadinessStatus } from "@/types";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-export async function GET() {
+const VALID_READINESS_FILTERS = new Set<ReadinessStatus>([
+  "ready",
+  "low_reserve",
+  "not_ready",
+]);
+
+export async function GET(request: NextRequest) {
   if (!(await refreshMaintainerSession())) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
@@ -40,6 +47,7 @@ export async function GET() {
     contributors,
     total: allContributors.length,
     filtered: contributors.length,
+    registryMode: getRegistryMode(),
     ...(readinessParam !== null ? { readiness: readinessParam } : {}),
   });
 }
@@ -67,5 +75,9 @@ export async function POST(request: NextRequest) {
     },
   });
 
-  return NextResponse.json({ refreshed, contributors });
+  return NextResponse.json({
+    refreshed,
+    contributors,
+    registryMode: getRegistryMode(),
+  });
 }

--- a/src/lib/registry-mode.test.ts
+++ b/src/lib/registry-mode.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { getRegistryMode } from "@/lib/registry-mode";
+
+describe("getRegistryMode", () => {
+  afterEach(() => {
+    delete process.env.REGISTRY_MODE;
+  });
+
+  it("defaults to 'live' when unset", () => {
+    expect(getRegistryMode()).toBe("live");
+  });
+
+  it("returns 'synced' when explicitly configured", () => {
+    process.env.REGISTRY_MODE = "synced";
+    expect(getRegistryMode()).toBe("synced");
+  });
+
+  it("is case-insensitive and trims whitespace", () => {
+    process.env.REGISTRY_MODE = "  SYNCED  ";
+    expect(getRegistryMode()).toBe("synced");
+  });
+
+  it("falls back to 'live' for an unrecognized value instead of failing", () => {
+    process.env.REGISTRY_MODE = "bogus";
+    expect(getRegistryMode()).toBe("live");
+  });
+});

--- a/src/lib/registry-mode.ts
+++ b/src/lib/registry-mode.ts
@@ -1,0 +1,27 @@
+export type RegistryMode = "live" | "synced";
+
+const VALID_MODES = new Set<RegistryMode>(["live", "synced"]);
+
+/**
+ * Resolves the dashboard's registry mode, shared by every contributor-facing
+ * REST endpoint instead of each route re-deriving it independently:
+ *
+ * - `"live"` (default): reads reflect whatever is currently persisted, and
+ *   maintainers are expected to trigger a Horizon recheck (`POST
+ *   /api/contributors`, `/api/contributors/[id]`) to refresh it.
+ * - `"synced"`: signals that a scheduled contract-to-Postgres sync job
+ *   (`src/lib/contract-sync.ts`) is responsible for keeping registration
+ *   rows fresh, so read endpoints can trust Postgres without prompting a
+ *   maintainer to manually recheck.
+ *
+ * Reads are identical in both modes (Postgres is always the source of
+ * truth) — the mode only changes what a route reports about how fresh that
+ * data is expected to be. An unrecognized value falls back to `"live"`
+ * rather than failing closed, so a typo'd env var never breaks reads.
+ */
+export function getRegistryMode(): RegistryMode {
+  const raw = process.env.REGISTRY_MODE?.trim().toLowerCase();
+  return raw && VALID_MODES.has(raw as RegistryMode)
+    ? (raw as RegistryMode)
+    : "live";
+}

--- a/tests/api/contributors.test.ts
+++ b/tests/api/contributors.test.ts
@@ -111,6 +111,7 @@ describe("GET /api/contributors — no filter", () => {
     expect(json.total).toBe(5);
     expect(json.filtered).toBe(5);
     expect(json.readiness).toBeUndefined();
+    expect(json.registryMode).toBe("live");
   });
 });
 
@@ -249,43 +250,14 @@ describe("POST /api/contributors", () => {
       changed: 0,
       diffs: [],
     });
-    vi.mocked(getContributors).mockResolvedValue([] as any);
+    vi.mocked(getContributors).mockResolvedValue(allContributors);
 
     const r = post();
     const res = await POST(r);
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.refreshed).toBe(3);
-    expect(json.pagination).toBeDefined();
-    expect(json.pagination.page).toBe(1);
-    expect(json.pagination.total).toBe(3);
-  });
-
-  it("returns paginated results with custom page and limit", async () => {
-    vi.mocked(getServerSession).mockResolvedValue({
-      user: { id: "user-1", isMaintainer: true },
-    } as any);
-    vi.mocked(refreshAllContributors).mockResolvedValue(150);
-    vi.mocked(getContributors).mockResolvedValue({
-      contributors: Array.from({ length: 25 }),
-      total: 150,
-    } as any);
-
-    const r = new NextRequest(
-      "http://localhost:3000/api/contributors?page=2&limit=25",
-      {
-        method: "POST",
-        headers: sameOriginHeaders,
-      }
-    );
-    const res = await POST(r);
-    expect(res.status).toBe(200);
-    const json = await res.json();
-    expect(json.pagination.page).toBe(2);
-    expect(json.pagination.limit).toBe(25);
-    expect(json.pagination.total).toBe(150);
-    expect(json.pagination.pages).toBe(6);
-    expect(json.pagination.hasNextPage).toBe(true);
-    expect(json.pagination.hasPrevPage).toBe(true);
+    expect(json.contributors).toHaveLength(5);
+    expect(json.registryMode).toBe("live");
   });
 });


### PR DESCRIPTION
## Summary
- New `REGISTRY_MODE` env flag (`"live"` default / `"synced"`) via `src/lib/registry-mode.ts`, shared by the contributor REST endpoints instead of each route re-deriving similar state independently. `GET /api/contributors` and `GET /api/contributors/paginated` now both report it as `registryMode`.
- **Fixes a real bug on `main`**: `GET /api/contributors` referenced an undefined `request` variable and an undefined `VALID_READINESS_FILTERS` constant — a leftover from two PRs merged on top of each other without reconciling signatures (see `git blame`: one PR changed the auth check's signature, another added readiness-filter query-param handling assuming a `request` param that no longer existed). This meant the endpoint didn't even compile, and the `?readiness=` filter was completely non-functional. Both are fixed here.
- De-duplicates `/api/contributors/paginated`'s cursor-pagination logic by delegating to the existing, already-tested `getContributorsPaginated` (`src/lib/registrations.ts`) instead of re-implementing cursor handling directly against Prisma. Response shape (including the opaque `nextCursor`) is unchanged for the `useInfiniteContributors()` client, which already treats the cursor as opaque.
- Updated a couple of pre-existing tests in `tests/api/contributors.test.ts` that asserted on a `json.pagination` shape the `POST /api/contributors` handler has never actually returned.

## Test plan
- [x] `npx vitest run src/lib/registry-mode.test.ts src/app/api/contributors/paginated/route.test.ts tests/api/contributors.test.ts` — all passing
- [x] `tests/api/contributors.test.ts`, previously failing on `main` due to the `request`/`VALID_READINESS_FILTERS` bug, now passes in full
- [x] Confirmed via `git stash` that repo-wide test failures dropped from 36 (baseline `main`) to 18 — all remaining failures are pre-existing and unrelated to this change (verified unaffected by this diff)

Closes #14
Closes #15