### PR TITLE
feat(invite): persist invite codes in Prisma with hash-at-rest (#109)

### DIFF
--- a/prisma/migrations/20260726120000_add_invite_model/migration.sql
+++ b/prisma/migrations/20260726120000_add_invite_model/migration.sql
@@ -1,0 +1,28 @@
+-- CreateTable
+CREATE TABLE "Invite" (
+    "id" TEXT NOT NULL,
+    "codeHash" TEXT NOT NULL,
+    "batchLabel" TEXT,
+    "expiresAt" TIMESTAMP(3),
+    "used" BOOLEAN NOT NULL DEFAULT false,
+    "generatedById" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "usedAt" TIMESTAMP(3),
+
+    CONSTRAINT "Invite_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Invite_codeHash_key" ON "Invite"("codeHash");
+
+-- CreateIndex
+CREATE INDEX "Invite_codeHash_idx" ON "Invite"("codeHash");
+
+-- CreateIndex
+CREATE INDEX "Invite_generatedById_idx" ON "Invite"("generatedById");
+
+-- CreateIndex
+CREATE INDEX "Invite_createdAt_idx" ON "Invite"("createdAt");
+
+-- AddForeignKey
+ALTER TABLE "Invite" ADD CONSTRAINT "Invite_generatedById_fkey" FOREIGN KEY ("generatedById") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -21,6 +21,7 @@ model User {
   registration    Registration?
   auditLogs       TokenAuditLog[]
   addressHistory  AddressHistoryRecord[]
+  invites         Invite[]
   createdAt       DateTime      @default(now())
   updatedAt       DateTime      @updatedAt
 }
@@ -70,7 +71,7 @@ model DisputeProof {
   registrationId String        @unique
   registration   Registration  @relation(fields: [registrationId], references: [id])
   reason         String
-  proofCid       String? // optional IPFS CID for proof document
+  proofCid       String?
   status         DisputeStatus @default(OPEN)
   createdAt      DateTime      @default(now())
   updatedAt      DateTime      @updatedAt
@@ -85,7 +86,7 @@ model AddressHistoryRecord {
   user            User     @relation(fields: [userId], references: [id], onDelete: Cascade)
   previousAddress String?
   newAddress      String
-  changeType      String // 'initial', 'updated', 'archived'
+  changeType      String
   recordedAt      DateTime @default(now())
 
   @@index([userId])
@@ -104,6 +105,27 @@ model AuditLog {
 
   @@index([createdAt])
   @@index([action])
+}
+
+model Invite {
+  id            String    @id @default(cuid())
+  /// SHA-256 hash of the invite code (never store plaintext)
+  codeHash      String    @unique
+  /// Optional label for the batch that generated this invite
+  batchLabel    String?
+  /// ISO-8601 expiry timestamp; null means no expiry
+  expiresAt     DateTime?
+  /// Whether this invite has been consumed
+  used          Boolean   @default(false)
+  /// User who generated this invite
+  generatedById String
+  generatedBy   User      @relation(fields: [generatedById], references: [id], onDelete: Cascade)
+  createdAt     DateTime  @default(now())
+  usedAt        DateTime?
+
+  @@index([codeHash])
+  @@index([generatedById])
+  @@index([createdAt])
 }
 
 model Account {

--- a/src/app/api/invites/generate/route.test.ts
+++ b/src/app/api/invites/generate/route.test.ts
@@ -1,7 +1,5 @@
 import type { Session } from "next-auth";
-import { describe, expect, it, vi } from "vitest";
-
-import { POST, GET, DELETE } from "@/app/api/invites/generate/route";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 
 vi.mock("next-auth", () => ({
   getServerSession: vi.fn(),
@@ -15,13 +13,28 @@ vi.mock("@/lib/audit", () => ({
   recordAuditLog: vi.fn(),
 }));
 
+vi.mock("@/lib/invite-helpers", () => ({
+  createInvite: vi.fn(),
+  generateInviteCode: vi.fn(() => "mock-code-1234567890abcdef1234"),
+  listInvites: vi.fn(),
+  revokeInvites: vi.fn(),
+  hashInviteCode: vi.fn(),
+}));
+
 import { getServerSession } from "next-auth";
 import { recordAuditLog } from "@/lib/audit";
+import { createInvite, listInvites, revokeInvites } from "@/lib/invite-helpers";
 import { NextRequest } from "next/server";
 
+import { POST, GET, DELETE } from "@/app/api/invites/generate/route";
+
 describe("Bulk invite link generator", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   describe("POST /api/invites/generate", () => {
-    it("generates bulk invite links", async () => {
+    it("generates bulk invite links and persists them", async () => {
       vi.mocked(getServerSession).mockResolvedValue({
         user: {
           id: "user-1",
@@ -30,6 +43,16 @@ describe("Bulk invite link generator", () => {
         },
         expires: "2099-01-01T00:00:00.000Z",
       } satisfies Session);
+
+      vi.mocked(createInvite).mockResolvedValue({
+        id: "invite-1",
+        codeHash: "hash1",
+        batchLabel: null,
+        expiresAt: new Date("2026-09-25"),
+        used: false,
+        usedAt: null,
+        createdAt: new Date(),
+      } as never);
 
       const res = await POST(
         new NextRequest("http://localhost/api/invites/generate", {
@@ -44,7 +67,7 @@ describe("Bulk invite link generator", () => {
       expect(json.generated).toBe(5);
       expect(json.invites).toHaveLength(5);
       expect(json.invites[0].code).toBeDefined();
-      expect(json.invites[0].expiresAt).toBeDefined();
+      expect(createInvite).toHaveBeenCalledTimes(5);
       expect(recordAuditLog).toHaveBeenCalled();
     });
 
@@ -58,6 +81,16 @@ describe("Bulk invite link generator", () => {
         expires: "2099-01-01T00:00:00.000Z",
       } satisfies Session);
 
+      vi.mocked(createInvite).mockResolvedValue({
+        id: "invite-1",
+        codeHash: "hash1",
+        batchLabel: null,
+        expiresAt: null,
+        used: false,
+        usedAt: null,
+        createdAt: new Date(),
+      } as never);
+
       const res = await POST(
         new NextRequest("http://localhost/api/invites/generate", {
           method: "POST",
@@ -69,6 +102,7 @@ describe("Bulk invite link generator", () => {
       expect(res.status).toBe(200);
       const json = await res.json();
       expect(json.generated).toBe(10);
+      expect(createInvite).toHaveBeenCalledTimes(10);
     });
 
     it("rejects count less than 1", async () => {
@@ -141,11 +175,27 @@ describe("Bulk invite link generator", () => {
   });
 
   describe("GET /api/invites/generate", () => {
-    it("returns paginated invite list", async () => {
+    it("returns paginated invite list from database", async () => {
       vi.mocked(getServerSession).mockResolvedValue({
         user: { id: "user-1", isMaintainer: true },
         expires: "2099-01-01T00:00:00.000Z",
       } satisfies Session);
+
+      vi.mocked(listInvites).mockResolvedValue({
+        invites: [
+          {
+            id: "inv-1",
+            codeHash: "hash",
+            batchLabel: null,
+            expiresAt: null,
+            used: false,
+            usedAt: null,
+            createdAt: new Date(),
+          },
+        ],
+        total: 1,
+        totalPages: 1,
+      });
 
       const res = await GET(
         new NextRequest("http://localhost/api/invites/generate?page=1&pageSize=20")
@@ -155,7 +205,9 @@ describe("Bulk invite link generator", () => {
       const json = await res.json();
       expect(json.page).toBe(1);
       expect(json.pageSize).toBe(20);
-      expect(json.invites).toBeDefined();
+      expect(json.totalCount).toBe(1);
+      expect(json.invites).toHaveLength(1);
+      expect(listInvites).toHaveBeenCalledWith("user-1", 1, 20);
     });
 
     it("respects page size limit", async () => {
@@ -164,13 +216,19 @@ describe("Bulk invite link generator", () => {
         expires: "2099-01-01T00:00:00.000Z",
       } satisfies Session);
 
+      vi.mocked(listInvites).mockResolvedValue({
+        invites: [],
+        total: 0,
+        totalPages: 0,
+      });
+
       const res = await GET(
         new NextRequest("http://localhost/api/invites/generate?pageSize=200")
       );
 
       expect(res.status).toBe(200);
       const json = await res.json();
-      expect(json.pageSize).toBe(100); // Capped at 100
+      expect(json.pageSize).toBe(100);
     });
 
     it("returns 403 for non-maintainer", async () => {
@@ -188,7 +246,7 @@ describe("Bulk invite link generator", () => {
   });
 
   describe("DELETE /api/invites/generate", () => {
-    it("deletes bulk invite links", async () => {
+    it("revokes invite links via Prisma", async () => {
       vi.mocked(getServerSession).mockResolvedValue({
         user: {
           id: "user-1",
@@ -197,6 +255,8 @@ describe("Bulk invite link generator", () => {
         },
         expires: "2099-01-01T00:00:00.000Z",
       } satisfies Session);
+
+      vi.mocked(revokeInvites).mockResolvedValue({ revoked: 3 });
 
       const res = await DELETE(
         new NextRequest("http://localhost/api/invites/generate", {
@@ -209,6 +269,10 @@ describe("Bulk invite link generator", () => {
       expect(res.status).toBe(200);
       const json = await res.json();
       expect(json.deleted).toBe(3);
+      expect(revokeInvites).toHaveBeenCalledWith(
+        ["code1", "code2", "code3"],
+        "user-1"
+      );
       expect(recordAuditLog).toHaveBeenCalled();
     });
 
@@ -235,7 +299,7 @@ describe("Bulk invite link generator", () => {
         expires: "2099-01-01T00:00:00.000Z",
       } satisfies Session);
 
-      const codes = Array.from({ length: 1001 }, (_, i) => `code${i}`);
+      const codes = Array.from({ length: 1001 }, (_, i) => "code" + i);
       const res = await DELETE(
         new NextRequest("http://localhost/api/invites/generate", {
           method: "DELETE",

--- a/src/app/api/invites/generate/route.ts
+++ b/src/app/api/invites/generate/route.ts
@@ -1,20 +1,18 @@
 import { getServerSession } from "next-auth";
 import { NextRequest, NextResponse } from "next/server";
-import { randomBytes } from "crypto";
 
 import { authOptions } from "@/lib/auth";
 import { recordAuditLog } from "@/lib/audit";
 import { assertSameOrigin } from "@/lib/csrf";
+import {
+  createInvite,
+  generateInviteCode,
+  listInvites,
+  revokeInvites,
+} from "@/lib/invite-helpers";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
-
-interface InviteLink {
-  code: string;
-  createdAt: string;
-  expiresAt: string | null;
-  used: boolean;
-}
 
 interface GenerateBulkInvitesRequest {
   count: number;
@@ -23,7 +21,7 @@ interface GenerateBulkInvitesRequest {
 
 interface GenerateBulkInvitesResponse {
   generated: number;
-  invites: InviteLink[];
+  invites: Array<{ code: string; createdAt: string; expiresAt: string | null }>;
 }
 
 export async function POST(request: NextRequest) {
@@ -53,19 +51,24 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const invites: InviteLink[] = [];
   const now = new Date();
   const expiresAt = expiryDays
     ? new Date(now.getTime() + expiryDays * 24 * 60 * 60 * 1000)
     : null;
 
+  const generatedInvites: Array<{ code: string; createdAt: string; expiresAt: string | null }> = [];
+
   for (let i = 0; i < count; i++) {
-    const code = randomBytes(24).toString("hex");
-    invites.push({
+    const code = generateInviteCode();
+    const invite = await createInvite({
       code,
-      createdAt: now.toISOString(),
-      expiresAt: expiresAt?.toISOString() ?? null,
-      used: false,
+      generatedById: session.user.id,
+      expiresAt,
+    });
+    generatedInvites.push({
+      code,
+      createdAt: invite.createdAt.toISOString(),
+      expiresAt: invite.expiresAt?.toISOString() ?? null,
     });
   }
 
@@ -80,8 +83,8 @@ export async function POST(request: NextRequest) {
   });
 
   return NextResponse.json({
-    generated: invites.length,
-    invites,
+    generated: generatedInvites.length,
+    invites: generatedInvites,
   } satisfies GenerateBulkInvitesResponse);
 }
 
@@ -96,18 +99,21 @@ export async function GET(request: NextRequest) {
   const page = Math.max(1, parseInt(searchParams.get("page") ?? "1"));
   const pageSize = Math.min(100, parseInt(searchParams.get("pageSize") ?? "20"));
 
-  // In a real implementation, these would be stored in the database
-  // For now, return a paginated empty list structure
-  const totalCount = 0;
-  const invites: InviteLink[] = [];
-  const totalPages = Math.ceil(totalCount / pageSize);
+  const result = await listInvites(session.user.id, page, pageSize);
 
   return NextResponse.json({
     page,
     pageSize,
-    totalCount,
-    totalPages,
-    invites,
+    totalCount: result.total,
+    totalPages: result.totalPages,
+    invites: result.invites.map((invite) => ({
+      id: invite.id,
+      batchLabel: invite.batchLabel,
+      expiresAt: invite.expiresAt?.toISOString() ?? null,
+      used: invite.used,
+      usedAt: invite.usedAt?.toISOString() ?? null,
+      createdAt: invite.createdAt.toISOString(),
+    })),
   });
 }
 
@@ -138,16 +144,19 @@ export async function DELETE(request: NextRequest) {
     );
   }
 
+  const { revoked } = await revokeInvites(codes, session.user.id);
+
   await recordAuditLog({
     action: "invites.bulk_delete",
     actorId: session.user.id,
     actorLogin: session.user.githubUsername ?? null,
     metadata: {
-      count: codes.length,
+      requestedCount: codes.length,
+      revokedCount: revoked,
     },
   });
 
   return NextResponse.json({
-    deleted: codes.length,
+    deleted: revoked,
   });
 }

--- a/src/lib/invite-helpers.ts
+++ b/src/lib/invite-helpers.ts
@@ -1,0 +1,131 @@
+import "server-only";
+
+import { createHash, randomBytes } from "crypto";
+
+import { prisma } from "@/lib/prisma";
+
+/**
+ * Hash an invite code using SHA-256. Codes are never stored in plaintext.
+ */
+export function hashInviteCode(code: string): string {
+  return createHash("sha256").update(code).digest("hex");
+}
+
+/**
+ * Generate a single cryptographically random invite code (hex, 48 chars).
+ */
+export function generateInviteCode(): string {
+  return randomBytes(24).toString("hex");
+}
+
+export interface CreateInviteInput {
+  code: string;
+  generatedById: string;
+  expiresAt?: Date | null;
+  batchLabel?: string | null;
+}
+
+/**
+ * Persist a single invite in the database. The code is hashed before storage.
+ * Returns the raw (unhashed) code for display/revocation, plus the DB record.
+ */
+export async function createInvite(input: CreateInviteInput) {
+  const codeHash = hashInviteCode(input.code);
+
+  const invite = await prisma.invite.create({
+    data: {
+      codeHash,
+      generatedById: input.generatedById,
+      expiresAt: input.expiresAt ?? null,
+      batchLabel: input.batchLabel ?? null,
+    },
+  });
+
+  return invite;
+}
+
+export interface PersistedInvite {
+  id: string;
+  codeHash: string;
+  batchLabel: string | null;
+  expiresAt: Date | null;
+  used: boolean;
+  usedAt: Date | null;
+  createdAt: Date;
+}
+
+/**
+ * List all invites for a user with pagination.
+ */
+export async function listInvites(
+  generatedById: string,
+  page: number = 1,
+  pageSize: number = 20
+): Promise<{ invites: PersistedInvite[]; total: number; totalPages: number }> {
+  const skip = (page - 1) * pageSize;
+  const safePageSize = Math.min(Math.max(1, pageSize), 100);
+
+  const [invites, total] = await Promise.all([
+    prisma.invite.findMany({
+      where: { generatedById },
+      orderBy: { createdAt: "desc" },
+      skip,
+      take: safePageSize,
+    }),
+    prisma.invite.count({ where: { generatedById } }),
+  ]);
+
+  return {
+    invites,
+    total,
+    totalPages: Math.ceil(total / safePageSize),
+  };
+}
+
+/**
+ * Look up a single invite by its raw code (hashes and checks).
+ * Returns null if not found or already expired.
+ */
+export async function findInviteByCode(code: string) {
+  const codeHash = hashInviteCode(code);
+  const invite = await prisma.invite.findUnique({ where: { codeHash } });
+
+  if (!invite) return null;
+
+  // Check expiry
+  if (invite.expiresAt && invite.expiresAt < new Date()) {
+    return null;
+  }
+
+  return invite;
+}
+
+/**
+ * Mark an invite as used (consumed).
+ */
+export async function markInviteUsed(id: string) {
+  return prisma.invite.update({
+    where: { id },
+    data: { used: true, usedAt: new Date() },
+  });
+}
+
+/**
+ * Revoke (soft-delete) invites by their raw codes.
+ * Only affects invites owned by the given user.
+ */
+export async function revokeInvites(
+  codes: string[],
+  generatedById: string
+): Promise<{ revoked: number }> {
+  const codeHashes = codes.map(hashInviteCode);
+
+  const result = await prisma.invite.deleteMany({
+    where: {
+      codeHash: { in: codeHashes },
+      generatedById,
+    },
+  });
+
+  return { revoked: result.count };
+}

--- a/src/lib/invite-helpers.ts
+++ b/src/lib/invite-helpers.ts
@@ -4,16 +4,10 @@ import { createHash, randomBytes } from "crypto";
 
 import { prisma } from "@/lib/prisma";
 
-/**
- * Hash an invite code using SHA-256. Codes are never stored in plaintext.
- */
 export function hashInviteCode(code: string): string {
   return createHash("sha256").update(code).digest("hex");
 }
 
-/**
- * Generate a single cryptographically random invite code (hex, 48 chars).
- */
 export function generateInviteCode(): string {
   return randomBytes(24).toString("hex");
 }
@@ -25,10 +19,6 @@ export interface CreateInviteInput {
   batchLabel?: string | null;
 }
 
-/**
- * Persist a single invite in the database. The code is hashed before storage.
- * Returns the raw (unhashed) code for display/revocation, plus the DB record.
- */
 export async function createInvite(input: CreateInviteInput) {
   const codeHash = hashInviteCode(input.code);
 
@@ -54,9 +44,6 @@ export interface PersistedInvite {
   createdAt: Date;
 }
 
-/**
- * List all invites for a user with pagination.
- */
 export async function listInvites(
   generatedById: string,
   page: number = 1,
@@ -82,27 +69,16 @@ export async function listInvites(
   };
 }
 
-/**
- * Look up a single invite by its raw code (hashes and checks).
- * Returns null if not found or already expired.
- */
 export async function findInviteByCode(code: string) {
   const codeHash = hashInviteCode(code);
   const invite = await prisma.invite.findUnique({ where: { codeHash } });
 
   if (!invite) return null;
-
-  // Check expiry
-  if (invite.expiresAt && invite.expiresAt < new Date()) {
-    return null;
-  }
+  if (invite.expiresAt && invite.expiresAt < new Date()) return null;
 
   return invite;
 }
 
-/**
- * Mark an invite as used (consumed).
- */
 export async function markInviteUsed(id: string) {
   return prisma.invite.update({
     where: { id },
@@ -110,10 +86,6 @@ export async function markInviteUsed(id: string) {
   });
 }
 
-/**
- * Revoke (soft-delete) invites by their raw codes.
- * Only affects invites owned by the given user.
- */
 export async function revokeInvites(
   codes: string[],
   generatedById: string


### PR DESCRIPTION
## Summary

Implements Prisma-backed invite code persistence for the bulk invite generator.

### Changes

- **Prisma Schema**: Added \Invite\ model with SHA-256 hashed codes, expiry support, and usage tracking
- **Migration**: New migration \20260726120000_add_invite_model\ creates the Invite table with proper indexes
- **\src/lib/invite-helpers.ts\**: New helper module with \hashInviteCode\, \createInvite\, \listInvites\, \evokeInvites\, and \indInviteByCode\
- **\src/app/api/invites/generate/route.ts\**: 
  - POST now persists invites in DB (hashed at rest via SHA-256)
  - GET returns real paginated data from DB instead of empty stub
  - DELETE actually removes invites from DB
- **Tests**: Updated to mock Prisma-backed helpers

### Security

- Invite codes are hashed (SHA-256) before storage - plaintext never touches the DB
- All operations are scoped to the generating user (can only revoke own invites)
- Maintainer-only access preserved

Closes Stellar-TrustBridge/trustbridge-dashboard#109