### PR TITLE
feat(progress): SSE streaming for batch recheck progress (#121)

### DIFF
--- a/src/app/api/contributors/queue/progress/route.ts
+++ b/src/app/api/contributors/queue/progress/route.ts
@@ -1,0 +1,116 @@
+import { NextRequest } from "next/server";
+
+import { requireMaintainerSession } from "@/lib/api-auth";
+import { backgroundQueue } from "@/lib/queue-worker";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(request: NextRequest) {
+  const session = await requireMaintainerSession();
+  if (!session) {
+    return new Response(JSON.stringify({ error: "Forbidden" }), {
+      status: 403,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const { searchParams } = new URL(request.url);
+  const jobId = searchParams.get("jobId")?.trim();
+
+  if (!jobId) {
+    return new Response(JSON.stringify({ error: "Job ID is required" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const encoder = new TextEncoder();
+  let isActive = true;
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      function sendEvent(data: Record<string, unknown>) {
+        if (!isActive) return;
+        controller.enqueue(
+          encoder.encode("data: " + JSON.stringify(data) + "\n\n")
+        );
+      }
+
+      // Verify job exists and belongs to the user
+      const job = await backgroundQueue.getJob(jobId);
+      if (!job) {
+        sendEvent({ type: "error", message: "Job not found" });
+        controller.close();
+        return;
+      }
+      if (job.ownerId && job.ownerId !== session!.user!.id) {
+        sendEvent({ type: "error", message: "Job not found" });
+        controller.close();
+        return;
+      }
+
+      // Send initial state
+      sendEvent({
+        type: "status",
+        jobId: job.id,
+        status: job.status,
+        createdAt: job.createdAt.toISOString(),
+        startedAt: job.startedAt?.toISOString() ?? null,
+      });
+
+      // Poll for updates
+      while (isActive) {
+        const currentJob = await backgroundQueue.getJob(jobId);
+        if (!currentJob) {
+          sendEvent({ type: "error", message: "Job not found" });
+          break;
+        }
+
+        if (currentJob.status === "completed") {
+          sendEvent({
+            type: "completed",
+            jobId: currentJob.id,
+            result: currentJob.result,
+            completedAt: currentJob.completedAt?.toISOString(),
+          });
+          break;
+        }
+
+        if (currentJob.status === "failed") {
+          sendEvent({
+            type: "failed",
+            jobId: currentJob.id,
+            error: currentJob.error,
+            completedAt: currentJob.completedAt?.toISOString(),
+          });
+          break;
+        }
+
+        if (currentJob.status === "processing") {
+          sendEvent({
+            type: "processing",
+            jobId: currentJob.id,
+            startedAt: currentJob.startedAt?.toISOString(),
+          });
+        }
+
+        // Wait before next poll
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+      }
+
+      controller.close();
+    },
+    cancel() {
+      isActive = false;
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    },
+  });
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -20,6 +20,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { countReadyContributors } from "@/lib/contributors";
+import { useJobProgress } from "@/lib/use-job-progress";
 import type {
   ContributorRow,
   NetworkConfig,
@@ -30,8 +31,15 @@ interface ContributorsResponse {
   contributors: ContributorRow[];
 }
 
+interface BatchRecheckResponse {
+  jobId: string;
+  status: string;
+  message: string;
+}
+
 export default function DashboardPage() {
   const queryClient = useQueryClient();
+  const { activeJobId, event, isStreaming, startProgress } = useJobProgress();
 
   const contributorsQuery = useQuery({
     queryKey: ["contributors"],
@@ -46,20 +54,18 @@ export default function DashboardPage() {
     mutationFn: async () => {
       const response = await fetch("/api/contributors", { method: "POST" });
       if (!response.ok) throw new Error("Re-check failed");
-      return (await response.json()) as ContributorsResponse & {
-        refreshed: number;
-      };
+      return (await response.json()) as BatchRecheckResponse;
     },
     onSuccess: (data) => {
-      queryClient.setQueryData(["contributors"], {
-        contributors: data.contributors,
-      });
+      if (data.jobId) {
+        startProgress(data.jobId);
+      }
     },
   });
 
   const recheckOneMutation = useMutation({
     mutationFn: async (id: string) => {
-      const response = await fetch(`/api/contributors/${id}`, {
+      const response = await fetch("/api/contributors/" + id, {
         method: "POST",
       });
       if (!response.ok) throw new Error("Re-check failed");
@@ -85,7 +91,7 @@ export default function DashboardPage() {
       const url = URL.createObjectURL(blob);
       const link = document.createElement("a");
       link.href = url;
-      link.download = `contributors-${new Date().toISOString().slice(0, 10)}.csv`;
+      link.download = "contributors-" + new Date().toISOString().slice(0, 10) + ".csv";
       link.click();
       URL.revokeObjectURL(url);
     },
@@ -99,7 +105,7 @@ export default function DashboardPage() {
       const url = URL.createObjectURL(blob);
       const link = document.createElement("a");
       link.href = url;
-      link.download = `contributors-${new Date().toISOString().slice(0, 10)}.json`;
+      link.download = "contributors-" + new Date().toISOString().slice(0, 10) + ".json";
       link.click();
       URL.revokeObjectURL(url);
     },
@@ -145,6 +151,17 @@ export default function DashboardPage() {
   const contributors = contributorsQuery.data?.contributors ?? [];
   const readyCount = countReadyContributors(contributors);
 
+  const isRecheckRunning = recheckMutation.isPending || isStreaming;
+  const recheckStatus = event?.type === "completed"
+    ? "Completed"
+    : event?.type === "failed"
+      ? "Failed"
+      : event?.type === "processing"
+        ? "Processing..."
+        : isStreaming
+          ? "Waiting..."
+          : null;
+
   return (
     <div className="mx-auto max-w-6xl px-4 py-10 sm:px-6">
       <div className="mb-8 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
@@ -159,14 +176,14 @@ export default function DashboardPage() {
           <Button
             variant="stellar"
             onClick={() => recheckMutation.mutate()}
-            disabled={recheckMutation.isPending}
+            disabled={isRecheckRunning}
           >
-            {recheckMutation.isPending ? (
+            {isRecheckRunning ? (
               <Loader2 className="h-4 w-4 animate-spin" />
             ) : (
               <RefreshCw className="h-4 w-4" />
             )}
-            Re-check all
+            {recheckStatus ?? "Re-check all"}
           </Button>
           <Button
             variant="outline"
@@ -183,6 +200,25 @@ export default function DashboardPage() {
           </Button>
         </div>
       </div>
+
+      {event?.type === "completed" && (
+        <Card className="mb-4 border-green-200 bg-green-50 dark:border-green-800 dark:bg-green-950">
+          <CardContent className="py-3 text-sm text-green-800 dark:text-green-200">
+            Batch recheck completed.{" "}
+            {event.result && typeof event.result === "object" && "refreshed" in event.result
+              ? (event.result as { refreshed: number }).refreshed + " contributors refreshed."
+              : ""}
+          </CardContent>
+        </Card>
+      )}
+
+      {event?.type === "failed" && (
+        <Card className="mb-4 border-red-200 bg-red-50 dark:border-red-800 dark:bg-red-950">
+          <CardContent className="py-3 text-sm text-red-800 dark:text-red-200">
+            Batch recheck failed: {event.error ?? "Unknown error"}
+          </CardContent>
+        </Card>
+      )}
 
       {networkQuery.data && (
         <NetworkStatusPanel config={networkQuery.data} className="mb-8" />

--- a/src/lib/use-job-progress.ts
+++ b/src/lib/use-job-progress.ts
@@ -1,0 +1,103 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+
+export interface JobProgressEvent {
+  type: "status" | "processing" | "completed" | "failed" | "error";
+  jobId?: string;
+  status?: string;
+  result?: Record<string, unknown>;
+  error?: string;
+  startedAt?: string | null;
+  completedAt?: string | null;
+  message?: string;
+  createdAt?: string | null;
+}
+
+export interface UseJobProgress {
+  /** Currently connected job ID, or null */
+  activeJobId: string | null;
+  /** Latest progress event */
+  event: JobProgressEvent | null;
+  /** Whether the SSE connection is open */
+  isStreaming: boolean;
+  /** Any connection or job error */
+  error: string | null;
+  /** Start streaming progress for a job */
+  startProgress: (jobId: string) => void;
+  /** Stop streaming */
+  stopProgress: () => void;
+}
+
+/**
+ * Hook that consumes SSE progress events for a background queue job.
+ *
+ * Usage:
+ * `	sx
+ * const { activeJobId, event, isStreaming, startProgress, stopProgress } = useJobProgress();
+ * // After enqueuing a job:
+ * startProgress(response.jobId);
+ * `
+ */
+export function useJobProgress(): UseJobProgress {
+  const [activeJobId, setActiveJobId] = useState<string | null>(null);
+  const [event, setEvent] = useState<JobProgressEvent | null>(null);
+  const [isStreaming, setIsStreaming] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const eventSourceRef = useRef<EventSource | null>(null);
+
+  const stopProgress = useCallback(() => {
+    if (eventSourceRef.current) {
+      eventSourceRef.current.close();
+      eventSourceRef.current = null;
+    }
+    setIsStreaming(false);
+  }, []);
+
+  const startProgress = useCallback(
+    (jobId: string) => {
+      stopProgress();
+
+      setActiveJobId(jobId);
+      setEvent(null);
+      setError(null);
+      setIsStreaming(true);
+
+      const url = "/api/contributors/queue/progress?jobId=" + encodeURIComponent(jobId);
+      const es = new EventSource(url);
+      eventSourceRef.current = es;
+
+      es.onmessage = (messageEvent) => {
+        try {
+          const data = JSON.parse(messageEvent.data) as JobProgressEvent;
+          setEvent(data);
+
+          if (data.type === "completed" || data.type === "failed" || data.type === "error") {
+            es.close();
+            eventSourceRef.current = null;
+            setIsStreaming(false);
+          }
+        } catch {
+          // ignore malformed events
+        }
+      };
+
+      es.onerror = () => {
+        setError("Connection lost. Refresh to retry.");
+        es.close();
+        eventSourceRef.current = null;
+        setIsStreaming(false);
+      };
+    },
+    [stopProgress]
+  );
+
+  return {
+    activeJobId,
+    event,
+    isStreaming,
+    error,
+    startProgress,
+    stopProgress,
+  };
+}


### PR DESCRIPTION
## Summary

Adds real-time SSE progress events for batch Horizon rechecks, with a React hook for the dashboard UI.

### Changes

- **\src/app/api/contributors/queue/progress/route.ts\**: New SSE endpoint that streams job lifecycle events (status -> processing -> completed/failed)
- **\src/lib/use-job-progress.ts\**: React hook that manages EventSource connection and parses progress events
- **\src/app/dashboard/page.tsx\**: 
  - "Re-check all" now enqueues and streams progress via SSE
  - Button shows live status (Waiting... / Processing... / Completed / Failed)
  - Success/failure cards shown inline after completion

### Security

- SSE endpoint is maintainer-only (requires valid session)
- Owner-scoped: users can only stream progress for their own jobs (job.ownerId check)
- No data from other orgs' jobs is leaked

### UX

- Button text updates in real-time as the job progresses
- Green card on success shows contributor count
- Red card on failure shows error message
- No page refresh required

Closes Stellar-TrustBridge/trustbridge-dashboard#121