### PR TITLE
Plain-language readiness copy, register E2E, dark-mode polish, a11y e…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@
 
 # testing
 /coverage
+/test-results/
+/playwright-report/
+/playwright/.cache/
 
 # next.js
 /.next/

--- a/docs/CSV_EXPORT_GUIDE.md
+++ b/docs/CSV_EXPORT_GUIDE.md
@@ -29,6 +29,35 @@ The CSV export includes the following columns:
 - `horizonNextAction` — Recommended next action
 - `freighterProofChallenge` — Freighter proof challenge
 
+## Export confirmation
+
+Every export from the dashboard goes through an accessible confirmation dialog
+(`ConfirmDialog` in `src/components/ui/confirm-dialog.tsx`) before a file is
+written. An export carries GitHub handles, Stellar addresses and balances, so
+the prompt names the row count and says plainly that the file is personal data.
+
+The dialog is what makes that prompt usable rather than something to click past:
+
+- `role="alertdialog"` with `aria-modal`, labelled by its title and described by
+  its body — the whole prompt is announced on open.
+- Focus lands on **Cancel**, not on the button that downloads the data.
+- Tab and Shift+Tab cycle inside the dialog; focus cannot reach the page behind.
+- ESC and the backdrop cancel, and focus returns to the button that opened it.
+- Cancel stays enabled even mid-export, so a keyboard user is never trapped.
+- Confirm fires at most once per opening — a double click cannot download twice.
+
+When the selection contains stale rows, the staleness warning is rendered
+**inside** the dialog's described region rather than as a second, native
+`window.confirm()`. Call sites therefore pass `force` to
+`exportContributorsCsv()` / `exportContributorsJson()` after the dialog is
+accepted: stacking a second prompt is how confirmations get ignored.
+
+The dialog is a client-side check on top of the API's authorization, not a
+replacement for it — `/api/contributors/export/*` still enforces the maintainer
+session on every request.
+
+`src/components/ui/confirm-dialog.test.tsx` holds these guarantees as tests.
+
 ## Before sending payments
 
 Re-run readiness checks, exclude not-ready contributors, and keep the export alongside the transaction batch hash for later review.

--- a/docs/E2E_TESTING.md
+++ b/docs/E2E_TESTING.md
@@ -1,0 +1,111 @@
+# End-to-End Testing
+
+Playwright drives the dashboard in a real Chromium against a locally-started
+Next.js dev server. Everything the app would reach over the network — GitHub,
+Horizon, the database, the Freighter extension — is mocked.
+
+```bash
+npx playwright test                     # all specs
+npx playwright test tests/e2e/register.spec.ts
+npx playwright test --ui                # watch mode
+npx playwright show-report              # last run
+```
+
+| Spec | Journey |
+| --- | --- |
+| `tests/e2e/register.spec.ts` | Contributor registration: sign in, paste an address, read the readiness result, save, copy the Freighter proof. |
+| `tests/e2e/maintainer.spec.ts` | Maintainer dashboard: access control, contributor table, re-check, metrics, settings. |
+
+## Signing in without GitHub
+
+Two things have to believe the user is signed in, and they are checked in
+different places:
+
+1. **The server.** `withAuth` in `src/middleware.ts` guards `/register` and
+   `/dashboard` by decoding a NextAuth **JWT cookie**. Intercepting
+   `/api/auth/session` does not fool it — without the cookie the request is
+   redirected to the sign-in page and the form never renders.
+2. **The client.** `SessionProvider` reads `/api/auth/session` to populate
+   `useSession()`.
+
+`signInAsContributor(context, page)` in `tests/e2e/helpers.ts` does both: it
+mints a genuine session token with `encode()` from `next-auth/jwt`, sets it as
+`next-auth.session-token`, and route-intercepts the session endpoint. No GitHub
+round trip is involved, and no OAuth credentials are needed.
+
+Signing the token means the test process and the dev server must share a secret.
+`tests/e2e/env.ts` resolves it — `NEXTAUTH_SECRET` when the environment sets one
+(CI does), otherwise a fixed local default — and `playwright.config.ts` passes
+the same value into the `next dev` it starts. If you run the server yourself and
+point the tests at it with `E2E_BASE_URL`, export `NEXTAUTH_SECRET` for both.
+
+For maintainer-only routes, pass `{ isMaintainer: true }`.
+
+## Mocking APIs
+
+`interceptApi(page, pattern, body, status)` fulfils a route with canned JSON.
+For anything stateful, route it by hand: the register spec serves
+`GET /api/register` from a fixture that `POST /api/register` mutates, so the
+"current registration" card only appears if the mutation's invalidate-and-refetch
+wiring actually works. That is the kind of bug a unit test cannot see.
+
+`DATABASE_URL` is set to a placeholder. The dev server logs Prisma connection
+errors for routes no test exercises; that is expected and not a failure.
+
+## Freighter
+
+Freighter is a browser extension and is never installed in CI. The register spec
+covers both states without one:
+
+- **Not installed** (the default): the card says Freighter was not detected, the
+  sign button is absent, and copy-to-clipboard still works.
+- **Installed**: `installFreighterStub(page)` uses `page.addInitScript()` to put
+  a `window.freighterApi` with a recording `signMessage()` on the page before any
+  app script runs. The test then asserts the signed message contains the pasted
+  address.
+
+If real SDK signing lands later, the stub is the seam to replace.
+
+## Clipboard
+
+The copy-proof test reads the clipboard back, which needs permissions:
+
+```ts
+test.use({ permissions: ["clipboard-read", "clipboard-write"] });
+```
+
+This is Chromium-only, which is fine — `playwright.config.ts` runs a single
+chromium project. If a WebKit or Firefox project is added, the clipboard tests
+need to be skipped there, since neither supports those permissions. The
+component also handles the case where the Clipboard API is unavailable
+altogether (an insecure origin, a denied permission) by telling the user to
+select and copy the challenge by hand, rather than failing silently.
+
+## Selectors
+
+Use `data-testid`. The user-visible copy on the register page is deliberately
+under revision (`docs/READINESS_MODEL.md`), so specs that match on wording break
+for reasons that have nothing to do with the journey.
+
+Test ids currently relied on:
+
+| Test id | Where |
+| --- | --- |
+| `register-page`, `maintainer-error` | `src/app/register/RegisterClient.tsx` |
+| `current-registration`, `current-registration-address` | ” |
+| `save-registration`, `registration-saved`, `registration-error` | ” |
+| `stellar-address-input`, `address-check-result`, `next-action-copy` | `src/components/AddressInput.tsx` |
+| `readiness-badge-<status>`, `readiness-description`, `readiness-next-step` | `src/components/TrustlineStatusBadge.tsx` |
+| `trustline-guidance` | `src/components/TrustlineGuidancePanel.tsx` |
+| `freighter-proof-card`, `freighter-detection-status`, `freighter-challenge` | `src/components/FreighterProofCard.tsx` |
+| `copy-challenge`, `sign-challenge`, `freighter-copy-error`, `freighter-sign-error` | ” |
+| `confirm-dialog`, `confirm-dialog-confirm`, `confirm-dialog-cancel`, `confirm-dialog-warning` | `src/components/ui/confirm-dialog.tsx` |
+
+## Avoiding flakes
+
+- Assert on a state, never on a delay. `AddressInput` debounces for 500 ms
+  before calling `/api/check`; `expect(page.getByTestId("address-check-result"))
+  .toBeVisible()` waits for the result rather than for the debounce.
+- Register every route mock **before** `page.goto()`.
+- `fullyParallel` is off and CI retries twice — a test that only passes on retry
+  is a bug report, not a pass.

--- a/docs/READINESS_MODEL.md
+++ b/docs/READINESS_MODEL.md
@@ -1,17 +1,104 @@
 # Readiness Model
 
-The dashboard presents contributor payout readiness as a small set of maintainable states.
+TrustBridge pays contributors in **USDC on the Stellar network**. Before a
+payout can land, the contributor's wallet has to be able to accept it. The
+dashboard reduces that question to three states, shown as a badge everywhere a
+wallet appears.
 
-## Ready
+This document is the source of truth for **the words** shown to contributors.
+The algorithm behind the states lives in `computeReadiness()` in
+[`src/lib/readiness.ts`](../src/lib/readiness.ts) and is not described by this
+document beyond what a contributor needs to know.
 
-The account exists on Horizon, has the configured asset trustline, and meets the minimum XLM reserve.
+## Who reads what
 
-## Low reserve
+There are two audiences, and they get different text:
 
-The account exists and has the trustline, but its **spendable** XLM is below the configured threshold. The contributor may still receive assets, but future operations can fail if the reserve is too low.
+| Audience | Surface | Vocabulary |
+| --- | --- | --- |
+| Contributors | `TrustlineStatusBadge`, `TrustlineGuidancePanel`, `AddressInput` | Plain language. Any Stellar-only term is explained where it is used. |
+| Maintainers | The per-row **Horizon debug** panel (`ContributorDebugPanel` in `ContributorTable`), CSV/JSON exports, `/dashboard/metrics` | Raw field names, balances, reason codes, Horizon latency. |
 
-Spendable XLM is the raw native balance minus the Stellar minimum reserve (`baseReserve * (2 + subentries + sponsoring − sponsored)`) and any `selling_liabilities` — the raw balance alone can look healthy while the spendable amount is near zero once trustlines, offers, or signers are accounted for. See `computeSpendableXlmBalance()` in `src/lib/readiness.ts`.
+**Nothing jargon-heavy belongs in the contributor surfaces.** If a maintainer
+needs a Horizon field name or a raw reason code, it goes in the debug panel or
+the export, not in the badge.
 
-## Not ready
+## The three states
 
-The account is unfunded, the trustline is missing, or Horizon cannot complete the check. Maintainers should avoid payout export until the state changes.
+Copy is keyed by status in `READINESS_CONFIG` (`src/lib/readiness.ts`). Changing
+the words means changing that record — and `src/lib/readiness-copy.test.ts` will
+hold the new words to the same rules.
+
+### ✅ Ready
+
+**Badge:** Ready
+**What it means:** This wallet is set up and can receive USDC payouts.
+**What to do next:** Nothing to do — you are set for the next payout.
+
+Underneath: the account exists on Horizon, it holds the configured asset
+trustline, that trustline is authorized by the issuer, and spendable XLM meets
+the configured minimum.
+
+### ⚠️ Low balance
+
+**Badge:** Low balance
+**What it means:** This wallet can receive USDC, but it is running low on
+XLM — the small deposit Stellar keeps locked in every wallet.
+**What to do next:** Add a little more XLM so the wallet keeps working when the
+payout lands.
+
+Underneath: the account exists and holds an authorized trustline, but its
+**spendable** XLM is below the configured threshold. A payout can still arrive;
+subsequent operations may fail.
+
+Spendable XLM is the raw native balance minus the Stellar minimum reserve
+(`baseReserve * (2 + subentries + sponsoring − sponsored)`) and any
+`selling_liabilities`. The raw balance alone can look healthy while the spendable
+amount is near zero once trustlines, offers, or signers are accounted for. See
+`computeSpendableXlmBalance()` in `src/lib/readiness.ts`.
+
+### ❌ Not ready yet
+
+**Badge:** Not ready yet
+**What it means:** This wallet cannot receive USDC payouts yet.
+**What to do next:** Follow the setup steps: put some XLM in the wallet, then
+turn on USDC for it.
+
+Underneath: the account is unfunded, the trustline is missing, the trustline is
+present but not authorized by the issuer, or Horizon could not complete the
+check. Maintainers should avoid payout export until the state changes.
+
+## Reason codes
+
+A status says *whether* a wallet can be paid. The reason code says *why not*, and
+drives the single "what to do next" line the contributor sees. Reason codes are
+computed by `computeNextAction()` and worded in `WIZARD_ACTION_COPY`, both in
+[`src/lib/action-lookup.ts`](../src/lib/action-lookup.ts). They mirror the
+reason codes emitted by
+[trustbridge-action](https://github.com/Stellar-TrustBridge/trustbridge-action).
+
+| Reason code | Status it produces | What the contributor is told |
+| --- | --- | --- |
+| `fund_account` | Not ready yet | Send at least 1 XLM to this address — a Stellar wallet does not exist until someone puts a little XLM in it. |
+| `add_trustline` | Not ready yet | Turn on USDC for this wallet (Stellar calls this "adding a trustline"). |
+| `await_trustline_authorization` | Not ready yet | USDC is turned on, but the issuer has not approved this wallet yet. |
+| `increase_reserve` | Low balance | Add a little more XLM — Stellar keeps a small amount locked in every wallet as a deposit. |
+| `none` | Ready | Nothing to do — this wallet can receive payouts. |
+
+`computeNextAction()` checks these in order: funding, then trustline presence,
+then issuer authorization, then reserve. The first failing check wins, so a
+contributor is never handed two things to do at once.
+
+Each entry in `READINESS_CONFIG` carries the `reasonCodes` it can be produced
+by. `readiness-copy.test.ts` asserts that mapping against `computeNextAction()`
+for every state, so a badge can never promise something the wizard contradicts.
+
+## Rules for changing this copy
+
+1. **Words only.** Never change `computeReadiness()` to make a copy change work.
+2. **Explain the term where you use it.** "Trustline" and "reserve" are allowed
+   only alongside a plain-language gloss. The test enforces this.
+3. **No internal identifiers.** `low_reserve`, `trustline_authorized`,
+   `spendable_xlm_balance` and friends never appear in contributor copy.
+4. **One next step.** Every state ends with exactly one thing to do.
+5. **Update this file and `readiness-copy.test.ts` in the same change.**

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig, devices } from "@playwright/test";
 
+import { E2E_DATABASE_URL, E2E_NEXTAUTH_SECRET } from "./tests/e2e/env";
+
 /**
  * Playwright configuration for TrustBridge Dashboard maintainer E2E tests.
  *
@@ -30,6 +32,18 @@ export default defineConfig({
         url: "http://localhost:3000",
         reuseExistingServer: !process.env.CI,
         timeout: 60_000,
+        // The register spec signs its own NextAuth session cookie, so the dev
+        // server has to verify it with the same secret. See tests/e2e/env.ts.
+        env: {
+          NEXTAUTH_SECRET: E2E_NEXTAUTH_SECRET,
+          NEXTAUTH_URL: process.env.NEXTAUTH_URL ?? "http://localhost:3000",
+          DATABASE_URL: E2E_DATABASE_URL,
+          // Placeholders: `next dev` reads these at import time; no test ever
+          // completes a real OAuth round trip.
+          GITHUB_CLIENT_ID: process.env.GITHUB_CLIENT_ID ?? "e2e-placeholder",
+          GITHUB_CLIENT_SECRET:
+            process.env.GITHUB_CLIENT_SECRET ?? "e2e-placeholder",
+        },
       },
 
   projects: [

--- a/src/app/dashboard/metrics/page.tsx
+++ b/src/app/dashboard/metrics/page.tsx
@@ -75,7 +75,10 @@ export default function MetricsPage() {
 
   if (metricsQuery.isError) {
     return (
-      <p className="text-destructive py-8">
+      <p
+        className="my-8 rounded-lg border border-destructive/60 bg-destructive/5 px-4 py-3 text-sm text-destructive"
+        role="alert"
+      >
         Failed to load metrics. Make sure you are signed in as a maintainer.
       </p>
     );
@@ -129,7 +132,7 @@ export default function MetricsPage() {
               ≥ 7:1 contrast against the page background (WCAG AAA).
               Light mode: -700 on white/tinted bg gives ≥ 6.5:1 (WCAG AA). */}
           <div className="grid grid-cols-3 gap-4 text-center">
-            <div className="rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-4 dark:border-emerald-800 dark:bg-emerald-950/40">
+            <div className="rounded-lg border border-emerald-300 bg-emerald-50 px-3 py-4 dark:border-emerald-600 dark:bg-emerald-950/40">
               <p className="text-2xl font-bold text-emerald-700 dark:text-emerald-300">
                 {contributors.byStatus.ready}
               </p>
@@ -137,7 +140,7 @@ export default function MetricsPage() {
                 ✅ Ready
               </p>
             </div>
-            <div className="rounded-lg border border-amber-200 bg-amber-50 px-3 py-4 dark:border-amber-800 dark:bg-amber-950/40">
+            <div className="rounded-lg border border-amber-300 bg-amber-50 px-3 py-4 dark:border-amber-600 dark:bg-amber-950/40">
               <p className="text-2xl font-bold text-amber-700 dark:text-amber-300">
                 {contributors.byStatus.low_reserve}
               </p>
@@ -145,7 +148,7 @@ export default function MetricsPage() {
                 ⚠️ Low reserve
               </p>
             </div>
-            <div className="rounded-lg border border-red-200 bg-red-50 px-3 py-4 dark:border-red-800 dark:bg-red-950/40">
+            <div className="rounded-lg border border-red-300 bg-red-50 px-3 py-4 dark:border-red-600 dark:bg-red-950/40">
               <p className="text-2xl font-bold text-red-700 dark:text-red-300">
                 {contributors.byStatus.not_ready}
               </p>
@@ -178,24 +181,44 @@ export default function MetricsPage() {
               No audit events recorded yet.
             </p>
           ) : (
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="border-b text-left text-muted-foreground">
-                  <th className="pb-2 font-medium">Action</th>
-                  <th className="pb-2 text-right font-medium">Count</th>
-                </tr>
-              </thead>
-              <tbody>
-                {Object.entries(audit.byAction)
-                  .sort((a, b) => b[1] - a[1])
-                  .map(([action, count]) => (
-                    <tr key={action} className="border-b last:border-0">
-                      <td className="py-2 font-mono text-xs">{action}</td>
-                      <td className="py-2 text-right tabular-nums">{count}</td>
-                    </tr>
-                  ))}
-              </tbody>
-            </table>
+            <div className="overflow-x-auto">
+              {/* `border-border-strong` rather than the default hairline: these
+                  row rules are the only thing separating one action count from
+                  the next, and the hairline is invisible on the dark page. */}
+              <table className="w-full min-w-[320px] text-sm">
+                <caption className="sr-only">
+                  Audit log entry counts by action, most frequent first.
+                </caption>
+                <thead>
+                  <tr className="border-b-2 border-border-strong text-left text-muted-foreground">
+                    <th scope="col" className="pb-2 font-medium">
+                      Action
+                    </th>
+                    <th scope="col" className="pb-2 text-right font-medium">
+                      Count
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {Object.entries(audit.byAction)
+                    .sort((a, b) => b[1] - a[1])
+                    .map(([action, count]) => (
+                      <tr
+                        key={action}
+                        className="border-b border-border-strong last:border-0"
+                      >
+                        <th
+                          scope="row"
+                          className="py-2 text-left font-mono text-xs font-normal"
+                        >
+                          {action}
+                        </th>
+                        <td className="py-2 text-right tabular-nums">{count}</td>
+                      </tr>
+                    ))}
+                </tbody>
+              </table>
+            </div>
           )}
         </CardContent>
       </Card>
@@ -266,10 +289,12 @@ function ConfigRow({
   hint: string;
 }) {
   return (
-    <div className="rounded-md border px-3 py-2">
+    <div className="rounded-md border border-border-strong px-3 py-2">
       <dt className="text-xs text-muted-foreground">{label}</dt>
       <dd className="mt-0.5 font-medium">{value}</dd>
-      <dd className="mt-0.5 font-mono text-xs text-muted-foreground/70">{hint}</dd>
+      {/* Full-strength muted foreground: the env-var name is the part a
+          maintainer copies, so it should not be the faintest thing on screen. */}
+      <dd className="mt-0.5 font-mono text-xs text-muted-foreground">{hint}</dd>
     </div>
   );
 }

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -250,7 +250,10 @@ export default function DashboardPage() {
       ) : (
         <ContributorTable
           contributors={contributors}
-          onExport={() => exportContributorsCsv(contributors)}
+          // `force`: ContributorTable has already shown the accessible export
+          // confirmation, staleness warning included. Leaving this unforced
+          // stacks a second, native `window.confirm()` on top of it.
+          onExport={() => exportContributorsCsv(contributors, true)}
           onRecheck={(id) => recheckOneMutation.mutate(id)}
           onLoadMore={() => void contributorsQuery.fetchNextPage()}
           hasMore={Boolean(contributorsQuery.hasNextPage)}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -21,6 +21,13 @@
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 210 40% 98%;
     --border: 214.3 31.8% 91.4%;
+    /*
+     * Divider for data grids (metrics audit table, Soroban event timeline).
+     * `--border` is a hairline tuned for card outlines — at 1.2:1 against the
+     * page it disappears the moment it has to separate rows of numbers. This
+     * one clears WCAG 1.4.11's 3:1 non-text minimum in both themes.
+     */
+    --border-strong: 214.3 31.8% 58%;
     --input: 214.3 31.8% 91.4%;
     --ring: 252 79% 48%;
     --radius: 0.75rem;
@@ -45,8 +52,12 @@
     /* Raised from L 30.6% → 65% so `text-destructive` on dark bg meets WCAG AA (was ~2.3:1, now ~5.9:1) */
     --destructive: 0 85% 65%;
     --destructive-foreground: 0 0% 10%;
-    --border: 217.2 32.6% 22%;
-    --input: 217.2 32.6% 22%;
+    /* Raised from 22% → 28%: at 22% a card outline sat at 1.6:1 on the dark
+       page and read as no outline at all. */
+    --border: 217.2 32.6% 28%;
+    /* Data-grid divider — 3.4:1 against both --background and --card. */
+    --border-strong: 215 20.2% 42%;
+    --input: 217.2 32.6% 28%;
     --ring: 252 79% 66%;
   }
 }

--- a/src/app/register/RegisterClient.tsx
+++ b/src/app/register/RegisterClient.tsx
@@ -78,9 +78,12 @@ export function RegisterClient() {
     buildWalletProofInfo(proofAddress, session?.user?.githubUsername ?? null);
 
   return (
-    <div className="mx-auto max-w-6xl px-4 py-10 sm:px-6">
+    <div className="mx-auto max-w-6xl px-4 py-10 sm:px-6" data-testid="register-page">
       {maintainerError && (
-        <div className="mb-6 rounded-lg border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm text-amber-800 dark:border-amber-400/40 dark:bg-amber-950/40 dark:text-amber-200">
+        <div
+          className="mb-6 rounded-lg border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm text-amber-800 dark:border-amber-400/40 dark:bg-amber-950/40 dark:text-amber-200"
+          data-testid="maintainer-error"
+        >
           Maintainer dashboard requires membership in the configured GitHub
           organization. You can still register your Stellar address here.
         </div>
@@ -100,13 +103,19 @@ export function RegisterClient() {
       <div className="grid gap-8 lg:grid-cols-5">
         <div className="lg:col-span-3 space-y-6">
           {existingAddress && (
-            <Card className="border-emerald-500/30 bg-emerald-500/5">
+            <Card
+              className="border-emerald-500/30 bg-emerald-500/5"
+              data-testid="current-registration"
+            >
               <CardHeader className="pb-3">
                 <CardTitle className="flex items-center gap-2 text-lg">
                   <CheckCircle2 className="h-5 w-5 text-emerald-500" />
                   Current registration
                 </CardTitle>
-                <CardDescription className="font-mono text-xs break-all">
+                <CardDescription
+                  className="font-mono text-xs break-all"
+                  data-testid="current-registration-address"
+                >
                   {existingAddress}
                 </CardDescription>
               </CardHeader>
@@ -114,6 +123,7 @@ export function RegisterClient() {
                 <CardContent>
                   <TrustlineStatusBadge
                     status={existingQuery.data.registration.readiness}
+                    showDescription
                   />
                 </CardContent>
               )}
@@ -126,9 +136,9 @@ export function RegisterClient() {
                 {existingAddress ? "Update Stellar address" : "Stellar address"}
               </CardTitle>
               <CardDescription>
-                Enter your public key (starts with G). Validation runs as you
-                type via Horizon, and the proof panel shows the exact Freighter
-                challenge maintainers can ask you to sign.
+                Paste the wallet address you want to be paid to. We check it as
+                you type and tell you what — if anything — is still missing. You
+                can save it now and finish the wallet setup afterwards.
               </CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">
@@ -139,7 +149,12 @@ export function RegisterClient() {
               />
 
               {saveMutation.isError && (
-                <p className="text-sm text-destructive" aria-live="polite">
+                <p
+                  className="text-sm text-destructive"
+                  aria-live="polite"
+                  role="alert"
+                  data-testid="registration-error"
+                >
                   {(saveMutation.error as Error).message}
                 </p>
               )}
@@ -148,6 +163,7 @@ export function RegisterClient() {
                 <p
                   className="text-sm text-emerald-600 dark:text-emerald-400"
                   aria-live="polite"
+                  data-testid="registration-saved"
                 >
                   Registration saved successfully.
                 </p>
@@ -157,6 +173,7 @@ export function RegisterClient() {
                 variant="stellar"
                 disabled={!address.trim() || saveMutation.isPending}
                 onClick={() => saveMutation.mutate(address.trim())}
+                data-testid="save-registration"
               >
                 {saveMutation.isPending ? (
                   <>

--- a/src/components/AddressInput.tsx
+++ b/src/components/AddressInput.tsx
@@ -71,14 +71,18 @@ export function AddressInput({
   return (
     <div className={cn("space-y-3", className)}>
       <div className="space-y-2">
-        <Label htmlFor="stellar-address">Stellar public address (G...)</Label>
+        <Label htmlFor="stellar-address">
+          Your Stellar wallet address (starts with G)
+        </Label>
         <p id="stellar-address-help" className="text-xs text-muted-foreground">
-          Paste the public payout address only. We validate funding, trustline,
-          authorization, and spendable XLM through Horizon.
+          Paste the public address only — the one starting with a capital G.
+          Never paste your secret key (it starts with S). We check the wallet as
+          you type and show what is still missing.
         </p>
         <div className="relative">
           <Input
             id="stellar-address"
+            data-testid="stellar-address-input"
             placeholder="GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
             value={value}
             onChange={(event) => onChange(event.target.value)}
@@ -95,36 +99,40 @@ export function AddressInput({
       </div>
 
       {result && (
-        <div className="rounded-lg border bg-muted/40 p-4 space-y-3" aria-live="polite">
+        <div
+          className="rounded-lg border bg-muted/40 p-4 space-y-3"
+          aria-live="polite"
+          data-testid="address-check-result"
+        >
           <div className="flex items-center justify-between gap-4">
-            <span className="text-sm font-medium">Readiness</span>
+            <span className="text-sm font-medium">Can this wallet be paid?</span>
             <TrustlineStatusBadge status={result.readiness} />
           </div>
           <dl className="grid grid-cols-2 gap-3 text-sm">
             <div>
-              <dt className="text-muted-foreground">Funded</dt>
+              <dt className="text-muted-foreground">Wallet exists on Stellar</dt>
               <dd className="font-medium">{result.funded ? "Yes" : "No"}</dd>
             </div>
             <div>
-              <dt className="text-muted-foreground">USDC trustline</dt>
+              <dt className="text-muted-foreground">USDC turned on</dt>
               <dd className="font-medium">{result.trustline ? "Yes" : "No"}</dd>
             </div>
             <div>
-              <dt className="text-muted-foreground">Authorized</dt>
+              <dt className="text-muted-foreground">Approved by USDC issuer</dt>
               <dd className="font-medium">
                 {result.trustline
                   ? result.trustline_authorized
                     ? "Yes"
-                    : "No (issuer authorization pending)"
+                    : "Not yet — waiting on the issuer"
                   : "—"}
               </dd>
             </div>
             <div>
-              <dt className="text-muted-foreground">XLM balance</dt>
+              <dt className="text-muted-foreground">XLM in the wallet</dt>
               <dd className="font-medium">{result.xlm_balance} XLM</dd>
             </div>
             <div>
-              <dt className="text-muted-foreground">Spendable XLM</dt>
+              <dt className="text-muted-foreground">XLM you can actually use</dt>
               <dd className="font-medium">{result.spendable_xlm_balance} XLM</dd>
             </div>
           </dl>
@@ -135,8 +143,8 @@ export function AddressInput({
               ))}
             </ul>
           )}
-          <p className="text-sm text-muted-foreground">
-            {WIZARD_ACTION_COPY[computeNextAction(result)]}
+          <p className="text-sm font-medium" data-testid="next-action-copy">
+            What to do next: {WIZARD_ACTION_COPY[computeNextAction(result)]}
           </p>
         </div>
       )}

--- a/src/components/ContributorTable.test.tsx
+++ b/src/components/ContributorTable.test.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/lib/csv", async () => {
@@ -11,6 +12,10 @@ vi.mock("@/lib/csv", async () => {
     ...actual,
     buildCsvFilename: vi.fn(() => "trustbridge-wave-2026-07-26.csv"),
     downloadCsv: vi.fn(),
+    // jsdom has no URL.createObjectURL, and the JSON export path now runs for
+    // real once the confirmation dialog is accepted.
+    buildJsonFilename: vi.fn(() => "trustbridge-wave-2026-07-26.json"),
+    downloadJson: vi.fn(),
   };
 });
 
@@ -81,5 +86,124 @@ describe("ContributorTable", () => {
     expect(vi.mocked(downloadCsv).mock.calls[0][1]).toContain(
       "Required USDC trustline is missing."
     );
+  });
+
+  // ── Export confirmation (issue #155) ────────────────────────────────────
+
+  describe("export confirmation dialog", () => {
+    /** `bob` was checked long enough ago to be stale in every test run. */
+    const staleContributors: ContributorRow[] = [
+      contributors[0],
+      { ...contributors[1], lastCheckedAt: null },
+    ];
+
+    it("does not export until the confirmation is accepted", async () => {
+      const user = userEvent.setup();
+      const onExport = vi.fn();
+      render(
+        <ContributorTable contributors={contributors} onExport={onExport} />
+      );
+
+      await user.click(screen.getByRole("button", { name: /Export CSV/i }));
+
+      expect(onExport).not.toHaveBeenCalled();
+      expect(screen.getByRole("alertdialog")).toBeInTheDocument();
+
+      await user.click(screen.getByRole("button", { name: /Download CSV/i }));
+      expect(onExport).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not export when the confirmation is cancelled", async () => {
+      const user = userEvent.setup();
+      const onExport = vi.fn();
+      render(
+        <ContributorTable contributors={contributors} onExport={onExport} />
+      );
+
+      await user.click(screen.getByRole("button", { name: /Export CSV/i }));
+      await user.keyboard("{Escape}");
+
+      expect(onExport).not.toHaveBeenCalled();
+      expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+    });
+
+    it("returns focus to the export button after cancelling", async () => {
+      const user = userEvent.setup();
+      render(
+        <ContributorTable contributors={contributors} onExport={vi.fn()} />
+      );
+
+      const exportButton = screen.getByRole("button", { name: /Export CSV/i });
+      await user.click(exportButton);
+      await user.keyboard("{Escape}");
+
+      expect(exportButton).toHaveFocus();
+    });
+
+    it("names the row count and the PII in the confirmation", async () => {
+      const user = userEvent.setup();
+      render(
+        <ContributorTable contributors={contributors} onExport={vi.fn()} />
+      );
+
+      await user.click(screen.getByRole("button", { name: /Export CSV/i }));
+
+      const dialog = screen.getByRole("alertdialog");
+      expect(dialog).toHaveTextContent(/2 contributors/i);
+      expect(dialog).toHaveTextContent(/personal data/i);
+    });
+
+    it("carries the stale-data warning into the dialog", async () => {
+      const user = userEvent.setup();
+      render(
+        <ContributorTable contributors={staleContributors} onExport={vi.fn()} />
+      );
+
+      await user.click(
+        screen.getByRole("button", { name: /Export CSV \(stale\)/i })
+      );
+
+      const dialog = screen.getByRole("alertdialog");
+      expect(dialog).toHaveTextContent(/have not been verified/i);
+      expect(dialog).toHaveTextContent(/may cause payout failures/i);
+    });
+
+    it("does not re-prompt with window.confirm once the dialog was accepted", async () => {
+      // The dialog already showed the staleness warning, so the export runs
+      // forced — a second native prompt is exactly the friction that gets
+      // confirmations clicked through without reading.
+      const user = userEvent.setup();
+      const confirmSpy = vi
+        .spyOn(window, "confirm")
+        .mockReturnValue(true);
+
+      render(
+        <ContributorTable contributors={staleContributors} onExport={vi.fn()} />
+      );
+
+      await user.click(
+        screen.getByRole("button", { name: /Export JSON \(stale\)/i })
+      );
+      await user.click(screen.getByRole("button", { name: /Download JSON/i }));
+
+      expect(confirmSpy).not.toHaveBeenCalled();
+      confirmSpy.mockRestore();
+    });
+
+    it("confirms the JSON export separately from the CSV export", async () => {
+      const user = userEvent.setup();
+      render(
+        <ContributorTable contributors={contributors} onExport={vi.fn()} />
+      );
+
+      await user.click(screen.getByRole("button", { name: /Export JSON/i }));
+
+      expect(
+        screen.getByRole("button", { name: /Download JSON/i })
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: /Download CSV/i })
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/components/ContributorTable.tsx
+++ b/src/components/ContributorTable.tsx
@@ -13,6 +13,7 @@ import {
 import { TrustlineStatusBadge } from "@/components/TrustlineStatusBadge";
 import { VerifiedBadge } from "@/components/VerifiedBadge";
 import { Button } from "@/components/ui/button";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { Input } from "@/components/ui/input";
 import {
   CONTRIBUTOR_COLUMNS,
@@ -113,9 +114,6 @@ function MobileContributorCard({
   row,
   onRecheck,
   recheckingId,
-  onLoadMore,
-  hasMore = false,
-  isLoadingMore = false,
 }: {
   row: ContributorRow;
   onRecheck?: (id: string) => void;
@@ -186,6 +184,9 @@ export function ContributorTable({
   onExport,
   onRecheck,
   recheckingId,
+  onLoadMore,
+  hasMore = false,
+  isLoadingMore = false,
   className,
 }: ContributorTableProps) {
   const columnPickerId = useId();
@@ -198,6 +199,9 @@ export function ContributorTable({
     () => defaultVisibleColumns()
   );
   const [showColumnPicker, setShowColumnPicker] = useState(false);
+  // Which export the confirmation dialog is standing in front of, or null when
+  // it is closed. Both formats share one dialog.
+  const [pendingExport, setPendingExport] = useState<"csv" | "json" | null>(null);
 
   const staleSummary = useMemo(
     () => buildStalenessSummary(contributors),
@@ -321,7 +325,7 @@ export function ContributorTable({
             <Button
               size="sm"
               variant={staleSummary.stale ? "destructive" : "outline"}
-              onClick={onExport}
+              onClick={() => setPendingExport("csv")}
               title={staleSummary.warning}
             >
               <Download className="h-4 w-4" />
@@ -330,7 +334,7 @@ export function ContributorTable({
             <Button
               size="sm"
               variant={staleSummary.stale ? "destructive" : "outline"}
-              onClick={() => exportContributorsJson(contributors, staleSummary.stale)}
+              onClick={() => setPendingExport("json")}
               title={staleSummary.warning}
             >
               <Download className="h-4 w-4" />
@@ -562,6 +566,49 @@ export function ContributorTable({
           </Button>
         </div>
       )}
+
+      {/*
+        A contributor export carries GitHub handles, wallet addresses and
+        balances, so it gets a real confirmation rather than the browser's
+        `window.confirm()`. `force` is passed on confirm because the maintainer
+        has now seen the staleness warning in the dialog — asking twice is how
+        confirmations get click-through-ignored.
+      */}
+      <ConfirmDialog
+        open={pendingExport !== null}
+        title={
+          pendingExport === "json"
+            ? "Export contributor data as JSON?"
+            : "Export contributor data as CSV?"
+        }
+        description={
+          <>
+            This downloads{" "}
+            <strong className="text-foreground">
+              {contributors.length} contributor
+              {contributors.length === 1 ? "" : "s"}
+            </strong>{" "}
+            to your device, including GitHub handles, Stellar addresses and
+            balances. Handle the file as personal data.
+          </>
+        }
+        warning={staleSummary.stale ? staleSummary.warning : undefined}
+        confirmLabel={
+          pendingExport === "json" ? "Download JSON" : "Download CSV"
+        }
+        cancelLabel="Cancel"
+        destructive={staleSummary.stale}
+        onCancel={() => setPendingExport(null)}
+        onConfirm={() => {
+          const format = pendingExport;
+          setPendingExport(null);
+          if (format === "json") {
+            exportContributorsJson(contributors, true);
+          } else {
+            onExport?.();
+          }
+        }}
+      />
     </div>
   );
 }

--- a/src/components/FreighterProofCard.tsx
+++ b/src/components/FreighterProofCard.tsx
@@ -34,6 +34,7 @@ export function FreighterProofCard({
 }: FreighterProofCardProps) {
   const [freighterDetected, setFreighterDetected] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [copyFailed, setCopyFailed] = useState(false);
   const [signed, setSigned] = useState(false);
   const [signing, setSigning] = useState(false);
   const [signError, setSignError] = useState(false);
@@ -46,9 +47,16 @@ export function FreighterProofCard({
   }, []);
 
   async function copyChallenge() {
-    await navigator.clipboard.writeText(proof.challenge);
-    setCopied(true);
-    window.setTimeout(() => setCopied(false), 1500);
+    try {
+      await navigator.clipboard.writeText(proof.challenge);
+      setCopyFailed(false);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // No Clipboard API (insecure origin, permission denied). The challenge is
+      // on screen and selectable, so say so rather than failing silently.
+      setCopyFailed(true);
+    }
   }
 
   async function signChallenge() {
@@ -69,7 +77,10 @@ export function FreighterProofCard({
   }
 
   return (
-    <Card className={cn("border-stellar-purple/20", className)}>
+    <Card
+      className={cn("border-stellar-purple/20", className)}
+      data-testid="freighter-proof-card"
+    >
       <CardHeader>
         <CardTitle className="flex items-center gap-2 text-lg">
           {freighterDetected ? (
@@ -93,6 +104,7 @@ export function FreighterProofCard({
               : "border-amber-500/30 bg-amber-500/5 text-amber-700 dark:text-amber-300"
           )}
           role="status"
+          data-testid="freighter-detection-status"
         >
           {freighterDetected
             ? "Freighter detected in this browser. You can use it to sign the ownership challenge."
@@ -110,6 +122,7 @@ export function FreighterProofCard({
           <pre
             className="overflow-x-auto rounded-md border bg-muted/40 p-3 text-xs whitespace-pre-wrap"
             aria-label="Freighter ownership proof challenge"
+            data-testid="freighter-challenge"
           >
             {proof.challenge}
           </pre>
@@ -122,18 +135,38 @@ export function FreighterProofCard({
           onClick={() => void copyChallenge()}
           disabled={!addressReady}
           aria-disabled={!addressReady}
+          data-testid="copy-challenge"
         >
           <Copy className="h-4 w-4" />
           {copied ? "Copied challenge" : "Copy challenge"}
         </Button>
         {freighterDetected && (
-          <Button variant="stellar" onClick={() => void signChallenge()} disabled={!addressReady || signing}>
+          <Button
+            variant="stellar"
+            onClick={() => void signChallenge()}
+            disabled={!addressReady || signing}
+            data-testid="sign-challenge"
+          >
             <PenLine className="h-4 w-4" />
             {signed ? "Challenge signed" : signing ? "Signing..." : "Sign challenge"}
           </Button>
         )}
+        {copyFailed && (
+          <p
+            className="text-xs text-destructive"
+            role="alert"
+            data-testid="freighter-copy-error"
+          >
+            Could not reach the clipboard. Select the challenge text above and
+            copy it manually.
+          </p>
+        )}
         {signError && (
-          <p className="text-xs text-destructive" role="alert">
+          <p
+            className="text-xs text-destructive"
+            role="alert"
+            data-testid="freighter-sign-error"
+          >
             Freighter did not sign the challenge. You can still copy it for a fallback review.
           </p>
         )}

--- a/src/components/SorobanEventTimeline.tsx
+++ b/src/components/SorobanEventTimeline.tsx
@@ -76,22 +76,43 @@ export function SorobanEventTimeline({
       </div>
 
       {errors.length > 0 && (
-        <ul className="rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3 text-sm text-destructive">
+        <ul
+          className="rounded-lg border border-destructive/60 bg-destructive/5 px-4 py-3 text-sm text-destructive"
+          role="alert"
+        >
           {errors.map((error) => (
             <li key={error}>• {error}</li>
           ))}
         </ul>
       )}
 
-      <div className="overflow-x-auto rounded-xl border">
+      {/* Dark mode: the default hairline border sits at ~1.6:1 on the page, so
+          a wall of monospace hashes ran together with nothing separating the
+          rows. `border-border-strong` clears WCAG 1.4.11's 3:1 in both themes,
+          and the header keeps its muted tint rather than a saturated fill —
+          see `dark-mode-contrast-audit.test.ts`. */}
+      <div className="overflow-x-auto rounded-xl border border-border-strong">
         <table className="w-full min-w-[720px] text-sm">
-          <thead className="bg-muted/50">
+          <caption className="sr-only">
+            Soroban contract events, newest ledger first.
+          </caption>
+          <thead className="border-b-2 border-border-strong bg-muted/50">
             <tr className="text-left">
-              <th className="px-4 py-3 font-medium">Type</th>
-              <th className="px-4 py-3 font-medium">Ledger</th>
-              <th className="px-4 py-3 font-medium">Contract</th>
-              <th className="px-4 py-3 font-medium">Topic</th>
-              <th className="px-4 py-3 font-medium">Closed</th>
+              <th scope="col" className="px-4 py-3 font-medium">
+                Type
+              </th>
+              <th scope="col" className="px-4 py-3 font-medium">
+                Ledger
+              </th>
+              <th scope="col" className="px-4 py-3 font-medium">
+                Contract
+              </th>
+              <th scope="col" className="px-4 py-3 font-medium">
+                Topic
+              </th>
+              <th scope="col" className="px-4 py-3 font-medium">
+                Closed
+              </th>
             </tr>
           </thead>
           <tbody>
@@ -108,7 +129,10 @@ export function SorobanEventTimeline({
               </tr>
             ) : (
               filtered.map((event) => (
-                <tr key={event.id} className="border-t bg-card/50">
+                <tr
+                  key={event.id}
+                  className="border-t border-border-strong bg-card/50"
+                >
                   <td className="px-4 py-3">
                     <Badge variant={TYPE_BADGE_VARIANT[event.type]}>
                       {event.type}

--- a/src/components/TrustlineGuidancePanel.tsx
+++ b/src/components/TrustlineGuidancePanel.tsx
@@ -14,24 +14,43 @@ import {
   STELLAR_LAB_TRUSTLINE_URL,
 } from "@/lib/constants";
 
+/**
+ * Contributor-facing setup guide.
+ *
+ * Written for a GitHub contributor who has never used Stellar: every term that
+ * only makes sense inside Stellar ("trustline", "reserve", "G-address") is
+ * introduced with what it actually does. Field-level Horizon detail stays in
+ * the maintainer "Horizon debug" panel — see `docs/READINESS_MODEL.md`.
+ */
 export function TrustlineGuidancePanel() {
   return (
-    <Card className="border-stellar-cyan/20 bg-gradient-to-br from-stellar-purple/5 to-stellar-cyan/5">
+    <Card
+      className="border-stellar-cyan/20 bg-gradient-to-br from-stellar-purple/5 to-stellar-cyan/5"
+      data-testid="trustline-guidance"
+    >
       <CardHeader>
-        <CardTitle className="text-lg">Set up your USDC trustline</CardTitle>
+        <CardTitle className="text-lg">
+          New to Stellar? Set your wallet up first
+        </CardTitle>
         <CardDescription>
-          TrustBridge Wave payouts use USDC on Stellar. Follow these steps before
-          submitting your address.
+          Payouts are sent as USDC on the Stellar network. A Stellar wallet has
+          to be switched on for USDC before it can receive any — these four
+          steps do that. It usually takes about ten minutes.
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4 text-sm">
         <ol className="list-decimal space-y-3 pl-5">
           <li>
-            Fund your Stellar account with at least 1 XLM (creates the account
-            on-network).
+            <span className="font-medium">Put some XLM in your wallet.</span>{" "}
+            XLM is Stellar&apos;s own coin. A wallet does not really exist until
+            it holds a little of it, so send at least 1 XLM to your address
+            before anything else.
           </li>
           <li>
-            Add a USDC trustline using{" "}
+            <span className="font-medium">Turn on USDC for that wallet.</span>{" "}
+            Stellar wallets opt in to each kind of token one at a time — the
+            official name for that opt-in is a{" "}
+            <em>trustline</em>. You can do it in{" "}
             <a
               href={LOBSTR_TRUSTLINE_URL}
               target="_blank"
@@ -40,7 +59,7 @@ export function TrustlineGuidancePanel() {
             >
               Lobstr <ExternalLink className="h-3 w-3" />
             </a>{" "}
-            or the{" "}
+            (a wallet app, easiest) or the{" "}
             <a
               href={STELLAR_LAB_TRUSTLINE_URL}
               target="_blank"
@@ -48,26 +67,43 @@ export function TrustlineGuidancePanel() {
               className="inline-flex items-center gap-1 text-stellar-cyan hover:underline"
             >
               Stellar Laboratory <ExternalLink className="h-3 w-3" />
-            </a>
-            .
+            </a>{" "}
+            (a developer tool).
           </li>
-          <li>Paste your public G-address below — we validate live via Horizon.</li>
           <li>
-            Copy the Freighter ownership proof challenge and sign it in your
-            wallet if a maintainer asks for proof of control.
+            <span className="font-medium">
+              Paste your public address below.
+            </span>{" "}
+            That is the one starting with a capital <code>G</code> — it is safe
+            to share, unlike your secret key, which starts with{" "}
+            <code>S</code> and should never be pasted anywhere. We check the
+            wallet as you type and tell you what is still missing.
           </li>
-          <li>Submit once the readiness badge shows ✅ Ready.</li>
+          <li>
+            <span className="font-medium">
+              Copy the ownership proof if asked.
+            </span>{" "}
+            The panel above shows a short piece of text. If a maintainer asks
+            you to prove the wallet is yours, sign that text in your wallet and
+            send it back.
+          </li>
         </ol>
+
+        <p className="text-muted-foreground">
+          Save your address as soon as it is entered — you do not have to wait
+          for the badge to turn green. Re-run the check any time after you
+          finish the setup.
+        </p>
 
         <div className="flex flex-wrap gap-2 pt-2">
           <Button asChild variant="outline" size="sm">
             <Link href={LOBSTR_TRUSTLINE_URL} target="_blank" rel="noreferrer">
-              Open Lobstr
+              Turn on USDC in Lobstr
             </Link>
           </Button>
           <Button asChild variant="outline" size="sm">
             <Link href={STELLAR_LAB_TRUSTLINE_URL} target="_blank" rel="noreferrer">
-              Stellar Lab
+              Use Stellar Laboratory
             </Link>
           </Button>
         </div>

--- a/src/components/TrustlineStatusBadge.tsx
+++ b/src/components/TrustlineStatusBadge.tsx
@@ -4,11 +4,17 @@ import React from "react";
 
 import { Badge } from "@/components/ui/badge";
 import { getReadinessConfig } from "@/lib/readiness";
+import { cn } from "@/lib/utils";
 import type { ReadinessStatus } from "@/types";
 
 interface TrustlineStatusBadgeProps {
   status: ReadinessStatus;
   className?: string;
+  /**
+   * Render the plain-language explanation and the next step underneath the
+   * badge. Off in dense contexts (tables), on wherever a contributor is being
+   * asked to act on the status.
+   */
   showDescription?: boolean;
 }
 
@@ -19,14 +25,33 @@ export function TrustlineStatusBadge({
 }: TrustlineStatusBadgeProps) {
   const config = getReadinessConfig(status);
 
-  return (
+  const badge = (
     <Badge
       variant={config.variant}
-      className={className}
-      title={showDescription ? config.description : undefined}
+      className={showDescription ? undefined : className}
+      // The tooltip carries the explanation everywhere the badge appears on its
+      // own — a table cell reading "Not ready yet" is otherwise a dead end.
+      title={config.description}
+      data-testid={`readiness-badge-${status}`}
     >
-      <span className="mr-1">{config.icon}</span>
+      <span className="mr-1" aria-hidden="true">
+        {config.icon}
+      </span>
       {config.label}
     </Badge>
+  );
+
+  if (!showDescription) return badge;
+
+  return (
+    <div className={cn("space-y-2", className)}>
+      {badge}
+      <p className="text-sm text-muted-foreground" data-testid="readiness-description">
+        {config.description}
+      </p>
+      <p className="text-sm font-medium" data-testid="readiness-next-step">
+        What to do next: {config.nextStep}
+      </p>
+    </div>
   );
 }

--- a/src/components/WavePrepWorkspace.test.tsx
+++ b/src/components/WavePrepWorkspace.test.tsx
@@ -93,7 +93,7 @@ describe("WavePrepWorkspace", () => {
     ).toBeInTheDocument();
   });
 
-  it("should call onExportCsv when export CSV is clicked", () => {
+  it("should call onExportCsv only after the confirmation is accepted", () => {
     const onExportCsv = vi.fn();
     render(
       <WavePrepWorkspace
@@ -102,15 +102,17 @@ describe("WavePrepWorkspace", () => {
       />
     );
 
-    const csvButton = screen.getByRole("button", {
-      name: /Export CSV/i,
-    });
+    fireEvent.click(screen.getByRole("button", { name: /Export CSV/i }));
 
-    fireEvent.click(csvButton);
-    expect(onExportCsv).toHaveBeenCalled();
+    // The click opens the confirmation; nothing has downloaded yet.
+    expect(onExportCsv).not.toHaveBeenCalled();
+    expect(screen.getByRole("alertdialog")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /Download CSV/i }));
+    expect(onExportCsv).toHaveBeenCalledTimes(1);
   });
 
-  it("should call onExportJson when export JSON is clicked", () => {
+  it("should call onExportJson only after the confirmation is accepted", () => {
     const onExportJson = vi.fn();
     render(
       <WavePrepWorkspace
@@ -119,12 +121,38 @@ describe("WavePrepWorkspace", () => {
       />
     );
 
-    const jsonButton = screen.getByRole("button", {
-      name: /Export JSON/i,
-    });
+    fireEvent.click(screen.getByRole("button", { name: /Export JSON/i }));
 
-    fireEvent.click(jsonButton);
-    expect(onExportJson).toHaveBeenCalled();
+    expect(onExportJson).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("button", { name: /Download JSON/i }));
+    expect(onExportJson).toHaveBeenCalledTimes(1);
+  });
+
+  it("should not export when the confirmation is cancelled", () => {
+    const onExportCsv = vi.fn();
+    render(
+      <WavePrepWorkspace
+        contributors={mockContributors}
+        onExportCsv={onExportCsv}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Export CSV/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^Cancel$/i }));
+
+    expect(onExportCsv).not.toHaveBeenCalled();
+    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+  });
+
+  it("warns in the dialog when the selected rows are stale", () => {
+    // `charlie` has never been checked, so the selection is stale.
+    render(<WavePrepWorkspace contributors={mockContributors} onExportCsv={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Export CSV/i }));
+
+    const dialog = screen.getByRole("alertdialog");
+    expect(dialog).toHaveTextContent(/have not been verified/i);
+    expect(dialog).toHaveTextContent(/personal data/i);
   });
 
   it("should disable export buttons when isExporting is true", () => {

--- a/src/components/WavePrepWorkspace.tsx
+++ b/src/components/WavePrepWorkspace.tsx
@@ -11,6 +11,8 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { buildStalenessSummary } from "@/lib/stale-export";
 import type { ContributorRow, ReadinessStatus } from "@/types";
 
 interface WavePrepWorkspaceProps {
@@ -31,6 +33,8 @@ export function WavePrepWorkspace({
   const [selectedStatuses, setSelectedStatuses] = useState<
     Set<ReadinessStatus>
   >(new Set<ReadinessStatus>(["ready", "low_reserve", "not_ready"]));
+  // Which export the confirmation is standing in front of, or null when closed.
+  const [pendingExport, setPendingExport] = useState<"csv" | "json" | null>(null);
 
   const stats = useMemo(() => {
     return {
@@ -48,6 +52,12 @@ export function WavePrepWorkspace({
   const filteredContributors = useMemo(() => {
     return contributors.filter((c) => selectedStatuses.has(c.readiness));
   }, [contributors, selectedStatuses]);
+
+  // Warn on the rows actually going into the file, not on the whole table.
+  const staleSummary = useMemo(
+    () => buildStalenessSummary(filteredContributors),
+    [filteredContributors]
+  );
 
   const toggleStatus = (status: ReadinessStatus) => {
     const newStatuses = new Set(selectedStatuses);
@@ -166,7 +176,7 @@ export function WavePrepWorkspace({
               <Button
                 variant="secondary"
                 size="sm"
-                onClick={onExportCsv}
+                onClick={() => setPendingExport("csv")}
                 disabled={isExporting || contributors.length === 0}
               >
                 Export CSV ({filteredContributors.length})
@@ -174,7 +184,7 @@ export function WavePrepWorkspace({
               <Button
                 variant="secondary"
                 size="sm"
-                onClick={onExportJson}
+                onClick={() => setPendingExport("json")}
                 disabled={isExporting || contributors.length === 0}
               >
                 Export JSON ({filteredContributors.length})
@@ -190,6 +200,48 @@ export function WavePrepWorkspace({
           </div>
         </CardContent>
       </Card>
+
+      {/*
+        Both handlers hit the maintainer-only export API routes, which do their
+        own authorization — this dialog is the human check in front of a file
+        full of PII, not a substitute for that check.
+      */}
+      <ConfirmDialog
+        open={pendingExport !== null}
+        title={
+          pendingExport === "json"
+            ? "Export this Wave selection as JSON?"
+            : "Export this Wave selection as CSV?"
+        }
+        description={
+          <>
+            This downloads{" "}
+            <strong className="text-foreground">
+              {filteredContributors.length} of {contributors.length} contributor
+              {contributors.length === 1 ? "" : "s"}
+            </strong>{" "}
+            to your device, including GitHub handles, Stellar addresses and
+            balances. Handle the file as personal data.
+          </>
+        }
+        warning={staleSummary.stale ? staleSummary.warning : undefined}
+        confirmLabel={
+          pendingExport === "json" ? "Download JSON" : "Download CSV"
+        }
+        cancelLabel="Cancel"
+        destructive={staleSummary.stale}
+        pending={isExporting}
+        onCancel={() => setPendingExport(null)}
+        onConfirm={() => {
+          const format = pendingExport;
+          setPendingExport(null);
+          if (format === "json") {
+            onExportJson?.();
+          } else {
+            onExportCsv?.();
+          }
+        }}
+      />
     </div>
   );
 }

--- a/src/components/ui/confirm-dialog.test.tsx
+++ b/src/components/ui/confirm-dialog.test.tsx
@@ -1,0 +1,289 @@
+/**
+ * Issue #155 — accessibility contract for the export confirmation dialog.
+ *
+ * These assertions are the reason the dialog exists in the first place: a
+ * confirmation that cannot be dismissed with a keyboard, or that drops focus
+ * into the page behind it, gets clicked through rather than read — and the
+ * thing behind this one downloads contributor PII.
+ */
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+
+function Harness({
+  onConfirm = vi.fn(),
+  onCancel,
+  ...props
+}: Partial<React.ComponentProps<typeof ConfirmDialog>> & {
+  onConfirm?: () => void;
+  onCancel?: () => void;
+}) {
+  const [open, setOpen] = React.useState(false);
+
+  return (
+    <div>
+      <button type="button" onClick={() => setOpen(true)}>
+        Export CSV
+      </button>
+      <button type="button">Some other page control</button>
+      <ConfirmDialog
+        open={open}
+        title="Export contributor data as CSV?"
+        description="This downloads 3 contributors to your device."
+        onConfirm={() => {
+          onConfirm();
+        }}
+        onCancel={() => {
+          setOpen(false);
+          onCancel?.();
+        }}
+        {...props}
+      />
+    </div>
+  );
+}
+
+async function openDialog() {
+  const user = userEvent.setup();
+  await user.click(screen.getByRole("button", { name: "Export CSV" }));
+  return user;
+}
+
+describe("ConfirmDialog — structure and labelling", () => {
+  it("renders nothing while closed", () => {
+    render(
+      <ConfirmDialog
+        open={false}
+        title="Export?"
+        description="body"
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+  });
+
+  it("is an aria-modal alertdialog labelled by its title and described by its body", async () => {
+    render(<Harness />);
+    await openDialog();
+
+    const dialog = screen.getByRole("alertdialog");
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+
+    const labelId = dialog.getAttribute("aria-labelledby");
+    const describedId = dialog.getAttribute("aria-describedby");
+    expect(labelId).toBeTruthy();
+    expect(describedId).toBeTruthy();
+
+    expect(document.getElementById(labelId!)).toHaveTextContent(
+      "Export contributor data as CSV?"
+    );
+    expect(document.getElementById(describedId!)).toHaveTextContent(
+      /downloads 3 contributors/i
+    );
+  });
+
+  it("renders the stale-data warning inside the described region", async () => {
+    render(
+      <Harness warning="2 of 3 contributors have not been verified in the last 24 hour(s)." />
+    );
+    await openDialog();
+
+    const dialog = screen.getByRole("alertdialog");
+    const describedId = dialog.getAttribute("aria-describedby");
+
+    // The warning has to be part of what is announced, not a visual aside.
+    expect(document.getElementById(describedId!)).toHaveTextContent(
+      /have not been verified/i
+    );
+  });
+
+  it("omits the warning region when there is nothing stale to say", async () => {
+    render(<Harness />);
+    await openDialog();
+
+    expect(
+      screen.queryByTestId("confirm-dialog-warning")
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("ConfirmDialog — focus management", () => {
+  it("moves focus to the cancel button on open", async () => {
+    render(<Harness />);
+    await openDialog();
+
+    expect(screen.getByRole("button", { name: "Cancel" })).toHaveFocus();
+  });
+
+  it("returns focus to the opener when dismissed", async () => {
+    render(<Harness />);
+    const user = await openDialog();
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(screen.getByRole("button", { name: "Export CSV" })).toHaveFocus();
+  });
+
+  it("traps Tab inside the dialog", async () => {
+    render(<Harness />);
+    const user = await openDialog();
+
+    const cancel = screen.getByRole("button", { name: "Cancel" });
+    const confirm = screen.getByRole("button", { name: "Confirm" });
+
+    expect(cancel).toHaveFocus();
+    await user.tab();
+    expect(confirm).toHaveFocus();
+
+    // Past the last control, focus wraps back to the first — it never reaches
+    // "Some other page control" behind the dialog.
+    await user.tab();
+    expect(cancel).toHaveFocus();
+  });
+
+  it("traps Shift+Tab inside the dialog", async () => {
+    render(<Harness />);
+    const user = await openDialog();
+
+    expect(screen.getByRole("button", { name: "Cancel" })).toHaveFocus();
+
+    await user.tab({ shift: true });
+    expect(screen.getByRole("button", { name: "Confirm" })).toHaveFocus();
+  });
+});
+
+describe("ConfirmDialog — dismissal", () => {
+  it("cancels on Escape and does not confirm", async () => {
+    const onConfirm = vi.fn();
+    const onCancel = vi.fn();
+    render(<Harness onConfirm={onConfirm} onCancel={onCancel} />);
+    const user = await openDialog();
+
+    await user.keyboard("{Escape}");
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onConfirm).not.toHaveBeenCalled();
+    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+  });
+
+  it("returns focus to the opener after Escape", async () => {
+    render(<Harness />);
+    const user = await openDialog();
+
+    await user.keyboard("{Escape}");
+
+    expect(screen.getByRole("button", { name: "Export CSV" })).toHaveFocus();
+  });
+
+  it("cancels when the backdrop is clicked", async () => {
+    const onCancel = vi.fn();
+    render(<Harness onCancel={onCancel} />);
+    await openDialog();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId("confirm-dialog-backdrop"));
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not cancel when the dialog body is clicked", async () => {
+    const onCancel = vi.fn();
+    render(<Harness onCancel={onCancel} />);
+    const user = await openDialog();
+
+    await user.click(screen.getByRole("heading", { level: 2 }));
+
+    expect(onCancel).not.toHaveBeenCalled();
+    expect(screen.getByRole("alertdialog")).toBeInTheDocument();
+  });
+});
+
+describe("ConfirmDialog — confirming", () => {
+  it("calls onConfirm once when confirmed", async () => {
+    const onConfirm = vi.fn();
+    render(<Harness onConfirm={onConfirm} />);
+    const user = await openDialog();
+
+    await user.click(screen.getByRole("button", { name: "Confirm" }));
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("can be confirmed from the keyboard", async () => {
+    const onConfirm = vi.fn();
+    render(<Harness onConfirm={onConfirm} />);
+    const user = await openDialog();
+
+    await user.tab();
+    await user.keyboard("{Enter}");
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores a second confirm before the dialog closes (double submit)", async () => {
+    // The parent may keep the dialog open across an await; a double click or a
+    // held Enter key must not fire a second export.
+    const onConfirm = vi.fn();
+    render(
+      <ConfirmDialog
+        open
+        title="Export?"
+        description="body"
+        onConfirm={onConfirm}
+        onCancel={vi.fn()}
+      />
+    );
+
+    const user = userEvent.setup();
+    const confirm = screen.getByRole("button", { name: "Confirm" });
+    await user.click(confirm);
+    await user.click(confirm);
+    await user.click(confirm);
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables the confirm button while an export is in flight", async () => {
+    const onConfirm = vi.fn();
+    render(<Harness pending onConfirm={onConfirm} />);
+    const user = await openDialog();
+
+    const confirm = screen.getByRole("button", { name: "Confirm" });
+    expect(confirm).toBeDisabled();
+
+    await user.click(confirm);
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it("keeps cancel available while pending so the user is never trapped", async () => {
+    const onCancel = vi.fn();
+    render(<Harness pending onCancel={onCancel} />);
+    const user = await openDialog();
+
+    const cancel = screen.getByRole("button", { name: "Cancel" });
+    expect(cancel).toBeEnabled();
+
+    await user.click(cancel);
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the supplied labels", async () => {
+    render(
+      <Harness confirmLabel="Download CSV" cancelLabel="Keep it private" />
+    );
+    await openDialog();
+
+    expect(
+      screen.getByRole("button", { name: "Download CSV" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Keep it private" })
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/ui/confirm-dialog.tsx
+++ b/src/components/ui/confirm-dialog.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import * as React from "react";
+import { AlertTriangle } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+/**
+ * Accessible confirmation dialog (issue #155).
+ *
+ * Exports can dump contributor PII, so the confirmation in front of them has to
+ * actually work for everyone: keyboard users must be able to reach the buttons
+ * and get out with ESC, and screen-reader users must be told what they are
+ * confirming. `window.confirm()` gave us that for free but cannot carry a stale
+ * data warning or a row count — this does, and implements the same guarantees
+ * by hand:
+ *
+ *   • `role="alertdialog"` + `aria-modal`, labelled by the title and described
+ *     by the body, so the whole prompt is announced on open.
+ *   • Focus moves to the cancel button on open — the safe default when the
+ *     confirm button is the one that leaks data.
+ *   • Tab and Shift+Tab cycle inside the dialog and cannot escape to the page
+ *     behind it.
+ *   • ESC cancels, and focus returns to whatever opened the dialog.
+ *   • Confirm fires at most once per opening, even on a double click or a
+ *     keyboard repeat.
+ *
+ * This is deliberately not a modal library: one dialog, no portal, no
+ * dependencies. If a second modal pattern shows up, revisit it then.
+ */
+
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  '[tabindex]:not([tabindex="-1"])',
+].join(",");
+
+export interface ConfirmDialogProps {
+  open: boolean;
+  title: string;
+  /** What the viewer is about to do, in a sentence. Announced on open. */
+  description: React.ReactNode;
+  /** Optional warning callout — e.g. the stale-export warning. */
+  warning?: React.ReactNode;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  /** Style the confirm button as destructive. */
+  destructive?: boolean;
+  /** Disables both buttons and shows the confirm button as busy. */
+  pending?: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+  className?: string;
+}
+
+export function ConfirmDialog({
+  open,
+  title,
+  description,
+  warning,
+  confirmLabel = "Confirm",
+  cancelLabel = "Cancel",
+  destructive = false,
+  pending = false,
+  onConfirm,
+  onCancel,
+  className,
+}: ConfirmDialogProps) {
+  const titleId = React.useId();
+  const descriptionId = React.useId();
+  const dialogRef = React.useRef<HTMLDivElement | null>(null);
+  const cancelRef = React.useRef<HTMLButtonElement | null>(null);
+  const openerRef = React.useRef<HTMLElement | null>(null);
+  // Guards the double submit: a second confirm before the parent has closed
+  // the dialog would fire a second export.
+  const confirmedRef = React.useRef(false);
+
+  // Remember the opener, move focus in, and put it back on close.
+  React.useEffect(() => {
+    if (!open) return;
+
+    confirmedRef.current = false;
+    openerRef.current =
+      document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null;
+    cancelRef.current?.focus();
+
+    return () => {
+      openerRef.current?.focus();
+    };
+  }, [open]);
+
+  function handleConfirm() {
+    if (pending || confirmedRef.current) return;
+    confirmedRef.current = true;
+    onConfirm();
+  }
+
+  function handleKeyDown(event: React.KeyboardEvent<HTMLDivElement>) {
+    if (event.key === "Escape") {
+      event.stopPropagation();
+      // ESC always works, even mid-flight: the parent decides whether an
+      // in-progress export can actually be abandoned.
+      onCancel();
+      return;
+    }
+
+    if (event.key !== "Tab") return;
+
+    const focusable = Array.from(
+      dialogRef.current?.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR) ?? []
+    ).filter((element) => !element.hasAttribute("aria-hidden"));
+
+    if (focusable.length === 0) {
+      event.preventDefault();
+      return;
+    }
+
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    const active = document.activeElement;
+
+    if (event.shiftKey && (active === first || !dialogRef.current?.contains(active))) {
+      event.preventDefault();
+      last.focus();
+      return;
+    }
+
+    if (!event.shiftKey && active === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  }
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-end justify-center overflow-y-auto bg-black/60 p-4 sm:items-center"
+      // Clicking the backdrop is the same as cancelling; the dialog itself
+      // stops the click so an in-dialog click never dismisses.
+      onMouseDown={onCancel}
+      data-testid="confirm-dialog-backdrop"
+    >
+      <div
+        ref={dialogRef}
+        role="alertdialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={descriptionId}
+        onKeyDown={handleKeyDown}
+        onMouseDown={(event) => event.stopPropagation()}
+        className={cn(
+          "w-full max-w-md rounded-xl border border-border-strong bg-card p-6 text-card-foreground shadow-xl",
+          className
+        )}
+        data-testid="confirm-dialog"
+      >
+        <h2 id={titleId} className="text-lg font-semibold">
+          {title}
+        </h2>
+
+        <div id={descriptionId} className="mt-2 space-y-3 text-sm text-muted-foreground">
+          <div>{description}</div>
+
+          {warning && (
+            <div
+              className="flex gap-2 rounded-lg border border-amber-300 bg-amber-50 px-3 py-2 text-amber-800 dark:border-amber-600 dark:bg-amber-950/40 dark:text-amber-200"
+              data-testid="confirm-dialog-warning"
+            >
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+              <div>{warning}</div>
+            </div>
+          )}
+        </div>
+
+        <div className="mt-6 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+          <Button
+            ref={cancelRef}
+            type="button"
+            variant="outline"
+            onClick={onCancel}
+            // Never disabled: an in-flight export must not trap the keyboard
+            // user inside the dialog with no way out but the confirm button.
+            data-testid="confirm-dialog-cancel"
+          >
+            {cancelLabel}
+          </Button>
+          <Button
+            type="button"
+            variant={destructive ? "destructive" : "stellar"}
+            onClick={handleConfirm}
+            disabled={pending}
+            data-testid="confirm-dialog-confirm"
+          >
+            {confirmLabel}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/action-lookup.ts
+++ b/src/lib/action-lookup.ts
@@ -13,16 +13,25 @@ export interface ActionLookupResult extends HorizonCheckResult {
   nextAction: WizardAction;
 }
 
+/**
+ * Plain-language "what to do next", keyed by reason code.
+ *
+ * These strings are read by contributors who may never have used Stellar, so
+ * each one names the jargon term once, in parentheses, and then explains the
+ * step in ordinary words. Keep them aligned with `docs/READINESS_MODEL.md` and
+ * with `READINESS_CONFIG` in `src/lib/readiness.ts` — `readiness-copy.test.ts`
+ * asserts that every reason code stays reachable and consistently worded.
+ */
 export const WIZARD_ACTION_COPY: Record<WizardAction, string> = {
   fund_account:
-    "Fund your Stellar account with at least 1 XLM to create it on-network.",
+    "Send at least 1 XLM to this address. A Stellar wallet does not exist until someone puts a little XLM in it, and payouts cannot reach a wallet that does not exist yet.",
   add_trustline:
-    "Add a USDC trustline — your account can't receive Wave payouts without it.",
+    "Turn on USDC for this wallet (Stellar calls this \"adding a trustline\"). A Stellar wallet has to opt in to each kind of token before it can receive it.",
   await_trustline_authorization:
-    "Your USDC trustline is present but not yet authorized by the issuer. Wait for authorization or contact the issuer before submitting.",
+    "USDC is turned on, but the company that issues USDC has not approved this wallet yet. Wait for that approval — if it takes more than a day, contact the issuer.",
   increase_reserve:
-    "Add more XLM. Your balance is below the configured minimum reserve.",
-  none: "You're ready for Wave payouts.",
+    "Add a little more XLM. Stellar keeps a small amount locked in every wallet as a deposit, and this wallet is below the amount it needs to keep working.",
+  none: "Nothing to do — this wallet can receive payouts.",
 };
 
 export function computeNextAction(

--- a/src/lib/dark-mode-contrast-audit.test.ts
+++ b/src/lib/dark-mode-contrast-audit.test.ts
@@ -134,6 +134,44 @@ const AMBER_950: [number, number, number] = [21, 92, 8];
 const RED_950: [number, number, number] = [0, 85, 7];
 
 // ---------------------------------------------------------------------------
+// Issue #153 — metrics page + Soroban timeline
+// ---------------------------------------------------------------------------
+
+const WHITE: [number, number, number] = [0, 0, 100];
+
+// Border tokens. `--border` is the hairline every card outline uses;
+// `--border-strong` is the new data-grid divider added for this wave.
+const DARK_BORDER: [number, number, number] = [217.2, 32.6, 28]; // was 22%
+const DARK_BORDER_STRONG: [number, number, number] = [215, 20.2, 42];
+const LIGHT_BORDER_STRONG: [number, number, number] = [214.3, 31.8, 58];
+
+// Dark surfaces the timeline paints on: `bg-muted/50` over the card (thead)
+// and `bg-card/50` over the page background (rows).
+const DARK_MUTED: [number, number, number] = [217.2, 32.6, 17.5];
+
+// Tinted status-box borders on the metrics page (raised -800 → -600 dark,
+// -200 → -300 light so the boxes keep an edge in both themes).
+const EMERALD_600: [number, number, number] = [161, 94, 30];
+const AMBER_600: [number, number, number] = [38, 92, 50];
+const RED_600: [number, number, number] = [0, 72, 51];
+const EMERALD_300_BORDER: [number, number, number] = [152, 76, 73];
+const AMBER_300_BORDER: [number, number, number] = [45, 93, 68];
+const RED_300_BORDER: [number, number, number] = [0, 94, 78];
+
+// Badge stops used by the timeline's type column via `variant="secondary"`.
+const DARK_SECONDARY_FG: [number, number, number] = [210, 40, 98];
+
+/** Contrast of `fg` against `overlay` at `alpha` composited over `base`. */
+function overlayContrast(
+  fg: [number, number, number],
+  overlay: [number, number, number],
+  alpha: number,
+  base: [number, number, number]
+): number {
+  return blendedContrastRatio(fg, overlay, alpha, base);
+}
+
+// ---------------------------------------------------------------------------
 // Test suites
 // ---------------------------------------------------------------------------
 
@@ -317,5 +355,159 @@ describe("WCAG AA: failure path — pre-fix values that violated WCAG (regressio
     const RED_400: [number, number, number] = [0, 91, 30];
     const ratio = r2(contrastRatio(RED_400, DARK_CARD));
     expect(ratio).toBeLessThan(4.5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #153 — dark-mode polish: metrics page & Soroban event timeline
+// ---------------------------------------------------------------------------
+
+describe("WCAG 1.4.11: data-grid dividers (issue #153)", () => {
+  // Non-text contrast: a rule that separates one row of data from the next is
+  // a meaningful graphical object, so it needs 3:1 — not the 1.6:1 the plain
+  // `--border` hairline was giving on the dark page.
+  const NON_TEXT_MIN = 3.0;
+
+  it("documents the old failure: --border at 22% was invisible on the dark page", () => {
+    const OLD_DARK_BORDER: [number, number, number] = [217.2, 32.6, 22];
+    const ratio = r2(contrastRatio(OLD_DARK_BORDER, DARK_BG));
+    // Must fail 3:1 — this is the defect the wave fixes.
+    expect(ratio).toBeLessThan(NON_TEXT_MIN);
+  });
+
+  it("--border-strong on --background meets non-text contrast (dark)", () => {
+    const ratio = r2(contrastRatio(DARK_BORDER_STRONG, DARK_BG));
+    expect(ratio).toBeGreaterThanOrEqual(NON_TEXT_MIN);
+  });
+
+  it("--border-strong on --card meets non-text contrast (dark)", () => {
+    const ratio = r2(contrastRatio(DARK_BORDER_STRONG, DARK_CARD));
+    expect(ratio).toBeGreaterThanOrEqual(NON_TEXT_MIN);
+  });
+
+  it("--border-strong on white meets non-text contrast (light)", () => {
+    const ratio = r2(contrastRatio(LIGHT_BORDER_STRONG, WHITE));
+    expect(ratio).toBeGreaterThanOrEqual(NON_TEXT_MIN);
+  });
+
+  it("--border-strong is not so light it becomes neon-on-dark", () => {
+    // The other half of "readable": a divider brighter than the body text
+    // turns a table into a grid of glowing lines. Keep it under the text.
+    const dividerVsText = r2(contrastRatio(DARK_BORDER_STRONG, DARK_FOREGROUND));
+    expect(dividerVsText).toBeGreaterThan(1);
+    expect(
+      r2(contrastRatio(DARK_BORDER_STRONG, DARK_BG))
+    ).toBeLessThan(r2(contrastRatio(DARK_FOREGROUND, DARK_BG)));
+  });
+
+  it("the raised --border hairline still beats the value it replaced", () => {
+    const OLD_DARK_BORDER: [number, number, number] = [217.2, 32.6, 22];
+    expect(r2(contrastRatio(DARK_BORDER, DARK_BG))).toBeGreaterThan(
+      r2(contrastRatio(OLD_DARK_BORDER, DARK_BG))
+    );
+  });
+});
+
+describe("WCAG AA: Soroban event timeline text (issue #153)", () => {
+  const NORMAL_TEXT_MIN = 4.5;
+
+  it("header text on bg-muted/50 over the dark card meets AA", () => {
+    const ratio = r2(overlayContrast(DARK_FOREGROUND, DARK_MUTED, 0.5, DARK_CARD));
+    expect(ratio).toBeGreaterThanOrEqual(NORMAL_TEXT_MIN);
+  });
+
+  it("muted header label on bg-muted/50 over the dark card meets AA", () => {
+    const ratio = r2(overlayContrast(DARK_MUTED_FG, DARK_MUTED, 0.5, DARK_CARD));
+    expect(ratio).toBeGreaterThanOrEqual(NORMAL_TEXT_MIN);
+  });
+
+  it("row body text on bg-card/50 over the dark background meets AA", () => {
+    const ratio = r2(overlayContrast(DARK_FOREGROUND, DARK_CARD, 0.5, DARK_BG));
+    expect(ratio).toBeGreaterThanOrEqual(NORMAL_TEXT_MIN);
+  });
+
+  it("the relative-time column (muted) on bg-card/50 meets AA", () => {
+    // Monospace hashes and relative timestamps are the smallest text in the
+    // table — they sit on the half-opacity card, not the card itself.
+    const ratio = r2(overlayContrast(DARK_MUTED_FG, DARK_CARD, 0.5, DARK_BG));
+    expect(ratio).toBeGreaterThanOrEqual(NORMAL_TEXT_MIN);
+  });
+
+  it("the 'system' type badge (secondary) is readable on the dark row", () => {
+    // Badge fill is --secondary; its foreground must clear AA against it.
+    const ratio = r2(contrastRatio(DARK_SECONDARY_FG, DARK_MUTED));
+    expect(ratio).toBeGreaterThanOrEqual(NORMAL_TEXT_MIN);
+  });
+
+  it("error-list text (--destructive) on bg-destructive/5 over the page meets AA", () => {
+    const ratio = r2(overlayContrast(DARK_DESTRUCTIVE, DARK_DESTRUCTIVE, 0.05, DARK_BG));
+    expect(ratio).toBeGreaterThanOrEqual(NORMAL_TEXT_MIN);
+  });
+
+  it("a heavier error tint would break AA — pins the /5 alpha in place", () => {
+    // The tint is decoration; the text is the point. At /10 the panel lifts
+    // enough to drag `text-destructive` down to ~4.0:1, so don't "polish" it up.
+    const heavier = r2(overlayContrast(DARK_DESTRUCTIVE, DARK_DESTRUCTIVE, 0.1, DARK_BG));
+    expect(heavier).toBeLessThan(NORMAL_TEXT_MIN);
+  });
+});
+
+describe("WCAG 1.4.11: metrics status-box borders (issue #153)", () => {
+  const NON_TEXT_MIN = 3.0;
+
+  it("documents the old failure: emerald-800 border on the dark page was under 3:1", () => {
+    const EMERALD_800: [number, number, number] = [163, 94, 20];
+    const ratio = r2(blendedContrastRatio(EMERALD_800, EMERALD_950, 0.4, DARK_BG));
+    expect(ratio).toBeLessThan(NON_TEXT_MIN);
+  });
+
+  it("emerald-600 border on the blended emerald box meets non-text contrast (dark)", () => {
+    const ratio = r2(blendedContrastRatio(EMERALD_600, EMERALD_950, 0.4, DARK_BG));
+    expect(ratio).toBeGreaterThanOrEqual(NON_TEXT_MIN);
+  });
+
+  it("amber-600 border on the blended amber box meets non-text contrast (dark)", () => {
+    const ratio = r2(blendedContrastRatio(AMBER_600, AMBER_950, 0.4, DARK_BG));
+    expect(ratio).toBeGreaterThanOrEqual(NON_TEXT_MIN);
+  });
+
+  it("red-600 border on the blended red box meets non-text contrast (dark)", () => {
+    const ratio = r2(blendedContrastRatio(RED_600, RED_950, 0.4, DARK_BG));
+    expect(ratio).toBeGreaterThanOrEqual(NON_TEXT_MIN);
+  });
+
+  it("light-mode status-box borders are darker than the -200 stops they replaced", () => {
+    const EMERALD_200: [number, number, number] = [152, 76, 85];
+    expect(r2(contrastRatio(EMERALD_300_BORDER, WHITE))).toBeGreaterThan(
+      r2(contrastRatio(EMERALD_200, WHITE))
+    );
+    expect(r2(contrastRatio(AMBER_300_BORDER, WHITE))).toBeGreaterThan(1);
+    expect(r2(contrastRatio(RED_300_BORDER, WHITE))).toBeGreaterThan(1);
+  });
+});
+
+describe("WCAG AA: metrics operational-config rows (issue #153)", () => {
+  const NORMAL_TEXT_MIN = 4.5;
+
+  it("the env-var hint at full muted-foreground meets AA on the dark card", () => {
+    // Was `text-muted-foreground/70`; the env-var name is the string a
+    // maintainer copies, so it runs at full strength now.
+    const ratio = r2(contrastRatio(DARK_MUTED_FG, DARK_CARD));
+    expect(ratio).toBeGreaterThanOrEqual(NORMAL_TEXT_MIN);
+  });
+
+  it("the config-row border clears non-text contrast against the dark card", () => {
+    // These boxes carry no fill — the border is the only thing making a config
+    // row a row, so it runs at full `--border-strong`, not a faded alpha.
+    const ratio = r2(contrastRatio(DARK_BORDER_STRONG, DARK_CARD));
+    expect(ratio).toBeGreaterThanOrEqual(3.0);
+    expect(ratio).toBeGreaterThan(r2(contrastRatio(DARK_BORDER, DARK_CARD)));
+  });
+
+  it("the metrics error alert text meets AA on its tinted dark panel", () => {
+    const ratio = r2(
+      blendedContrastRatio(DARK_DESTRUCTIVE, DARK_DESTRUCTIVE, 0.05, DARK_BG)
+    );
+    expect(ratio).toBeGreaterThanOrEqual(NORMAL_TEXT_MIN);
   });
 });

--- a/src/lib/readiness-copy.test.ts
+++ b/src/lib/readiness-copy.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Issue #151 — contributor-facing readiness copy.
+ *
+ * The badge/guidance strings are keyed by `ReadinessStatus` and by reason
+ * code, so they get a regression test: completeness, plain-language rules, and
+ * — the part that actually bites — agreement between what a badge promises and
+ * what `computeNextAction()` will tell the same contributor to do.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  computeNextAction,
+  WIZARD_ACTION_COPY,
+  type WizardAction,
+} from "@/lib/action-lookup";
+import {
+  describeReadiness,
+  describeReadinessWithNextStep,
+  getReadinessConfig,
+  getReadinessNextStep,
+  READINESS_CONFIG,
+} from "@/lib/readiness";
+import type { HorizonCheckResult, ReadinessStatus } from "@/types";
+
+const STATUSES: ReadinessStatus[] = ["ready", "low_reserve", "not_ready"];
+
+const ACTIONS: WizardAction[] = [
+  "fund_account",
+  "add_trustline",
+  "await_trustline_authorization",
+  "increase_reserve",
+  "none",
+];
+
+/**
+ * Terms that mean nothing to a contributor arriving from a GitHub issue. They
+ * are allowed in copy only when the same string also explains them, which is
+ * why each entry carries the phrase that has to sit alongside it.
+ */
+const JARGON_NEEDING_GLOSS: Array<{ term: RegExp; gloss: RegExp }> = [
+  { term: /trustline/i, gloss: /turn on|turned on|opt in|opts in/i },
+  { term: /\breserve\b/i, gloss: /deposit|locked|small amount/i },
+  { term: /\bhorizon\b/i, gloss: /never allowed/i },
+];
+
+/** Raw status codes and API field names must never reach contributor copy. */
+const LEAKED_INTERNALS = [
+  "low_reserve",
+  "not_ready",
+  "trustline_authorized",
+  "spendable_xlm_balance",
+  "reason_code",
+];
+
+describe("READINESS_CONFIG — keyed contributor copy", () => {
+  it("covers every readiness status", () => {
+    expect(Object.keys(READINESS_CONFIG).sort()).toEqual([...STATUSES].sort());
+  });
+
+  it.each(STATUSES)("%s has a label, an explanation, and a next step", (status) => {
+    const config = getReadinessConfig(status);
+
+    expect(config.label.trim().length).toBeGreaterThan(0);
+    expect(config.description.trim().length).toBeGreaterThan(0);
+    expect(config.nextStep.trim().length).toBeGreaterThan(0);
+    // Full sentences — these are read aloud by screen readers and pasted into
+    // support threads, not squeezed into a chip.
+    expect(config.description).toMatch(/\.$/);
+    expect(config.nextStep).toMatch(/\.$/);
+  });
+
+  it.each(STATUSES)("%s copy leaks no internal identifiers", (status) => {
+    const config = getReadinessConfig(status);
+    const copy = `${config.label} ${config.description} ${config.nextStep}`;
+
+    for (const internal of LEAKED_INTERNALS) {
+      expect(copy).not.toContain(internal);
+    }
+  });
+
+  it.each(STATUSES)("%s explains any Stellar jargon it uses", (status) => {
+    const config = getReadinessConfig(status);
+    const copy = `${config.description} ${config.nextStep}`;
+
+    for (const { term, gloss } of JARGON_NEEDING_GLOSS) {
+      if (term.test(copy)) {
+        expect(copy).toMatch(gloss);
+      }
+    }
+  });
+
+  it("keeps badge labels short enough for a table cell", () => {
+    for (const status of STATUSES) {
+      expect(getReadinessConfig(status).label.length).toBeLessThanOrEqual(20);
+    }
+  });
+
+  it("gives each status a distinct label", () => {
+    const labels = STATUSES.map((status) => getReadinessConfig(status).label);
+    expect(new Set(labels).size).toBe(labels.length);
+  });
+});
+
+describe("readiness copy helpers", () => {
+  it("describeReadiness returns the plain-language explanation", () => {
+    expect(describeReadiness("ready")).toBe(READINESS_CONFIG.ready.description);
+  });
+
+  it("getReadinessNextStep returns the what-to-do-next line", () => {
+    expect(getReadinessNextStep("low_reserve")).toBe(
+      READINESS_CONFIG.low_reserve.nextStep
+    );
+  });
+
+  it("describeReadinessWithNextStep joins explanation and next step", () => {
+    expect(describeReadinessWithNextStep("not_ready")).toBe(
+      `${READINESS_CONFIG.not_ready.description} ${READINESS_CONFIG.not_ready.nextStep}`
+    );
+  });
+});
+
+describe("WIZARD_ACTION_COPY — keyed reason-code copy", () => {
+  it("covers every reason code", () => {
+    expect(Object.keys(WIZARD_ACTION_COPY).sort()).toEqual([...ACTIONS].sort());
+  });
+
+  it.each(ACTIONS)("%s copy tells the contributor what to do", (action) => {
+    const copy = WIZARD_ACTION_COPY[action];
+    expect(copy.trim().length).toBeGreaterThan(0);
+    expect(copy).toMatch(/\.$/);
+  });
+
+  it.each(ACTIONS)("%s copy leaks no internal identifiers", (action) => {
+    for (const internal of LEAKED_INTERNALS) {
+      expect(WIZARD_ACTION_COPY[action]).not.toContain(internal);
+    }
+  });
+
+  it.each(ACTIONS)("%s copy explains any Stellar jargon it uses", (action) => {
+    const copy = WIZARD_ACTION_COPY[action];
+    for (const { term, gloss } of JARGON_NEEDING_GLOSS) {
+      if (term.test(copy)) {
+        expect(copy).toMatch(gloss);
+      }
+    }
+  });
+});
+
+// ── Accuracy: badge copy vs. the reason code the same account produces ──────
+
+function check(overrides: Partial<HorizonCheckResult>): HorizonCheckResult {
+  return {
+    funded: false,
+    trustline: false,
+    trustline_authorized: false,
+    verified: false,
+    xlm_balance: "0",
+    spendable_xlm_balance: "0",
+    usdc_balance: "0",
+    errors: [],
+    readiness: "not_ready",
+    ...overrides,
+  };
+}
+
+describe("badge copy stays accurate against Action reason codes", () => {
+  it("every reason code is claimed by exactly one readiness status", () => {
+    const claimed = STATUSES.flatMap(
+      (status) => getReadinessConfig(status).reasonCodes
+    );
+    expect(claimed.sort()).toEqual([...ACTIONS].sort());
+  });
+
+  const cases: Array<{
+    name: string;
+    result: HorizonCheckResult;
+    expectedAction: WizardAction;
+  }> = [
+    {
+      name: "unfunded account",
+      result: check({ readiness: "not_ready" }),
+      expectedAction: "fund_account",
+    },
+    {
+      name: "funded account with no trustline",
+      result: check({ funded: true, readiness: "not_ready" }),
+      expectedAction: "add_trustline",
+    },
+    {
+      name: "trustline awaiting issuer authorization",
+      result: check({ funded: true, trustline: true, readiness: "not_ready" }),
+      expectedAction: "await_trustline_authorization",
+    },
+    {
+      name: "low reserve",
+      result: check({
+        funded: true,
+        trustline: true,
+        trustline_authorized: true,
+        readiness: "low_reserve",
+      }),
+      expectedAction: "increase_reserve",
+    },
+    {
+      name: "ready",
+      result: check({
+        funded: true,
+        trustline: true,
+        trustline_authorized: true,
+        verified: true,
+        readiness: "ready",
+      }),
+      expectedAction: "none",
+    },
+  ];
+
+  it.each(cases)(
+    "$name: the badge's status lists the reason code the wizard actually returns",
+    ({ result, expectedAction }) => {
+      const action = computeNextAction(result);
+      expect(action).toBe(expectedAction);
+      expect(getReadinessConfig(result.readiness).reasonCodes).toContain(action);
+    }
+  );
+
+  it("only the ready badge says there is nothing to do", () => {
+    expect(getReadinessConfig("ready").nextStep).toMatch(/nothing to do/i);
+    expect(getReadinessConfig("low_reserve").nextStep).not.toMatch(
+      /nothing to do/i
+    );
+    expect(getReadinessConfig("not_ready").nextStep).not.toMatch(
+      /nothing to do/i
+    );
+  });
+
+  it("the low-balance badge and the increase_reserve reason code both ask for XLM", () => {
+    expect(getReadinessConfig("low_reserve").nextStep).toMatch(/XLM/);
+    expect(WIZARD_ACTION_COPY.increase_reserve).toMatch(/XLM/);
+  });
+
+  it("the not-ready badge does not promise a payout can arrive", () => {
+    expect(getReadinessConfig("not_ready").description).toMatch(
+      /cannot receive/i
+    );
+  });
+});

--- a/src/lib/readiness.ts
+++ b/src/lib/readiness.ts
@@ -1,11 +1,25 @@
+import type { WizardAction } from "@/lib/action-lookup";
 import { BASE_RESERVE_XLM, MIN_XLM_BALANCE } from "@/lib/constants";
 import type { HorizonCheckResult, ReadinessStatus } from "@/types";
 
 export interface ReadinessDisplayConfig {
+  /** Badge text. Short enough to sit in a table cell. */
   label: string;
   variant: "ready" | "warning" | "danger";
   icon: string;
+  /**
+   * One sentence of plain language explaining what the state means for the
+   * contributor. No Stellar vocabulary that is not explained in place.
+   */
   description: string;
+  /** The single next thing the contributor should do. */
+  nextStep: string;
+  /**
+   * Reason codes that can produce this status, in the order
+   * `computeNextAction()` checks them. Keeps the badge copy honest against
+   * `WIZARD_ACTION_COPY` — see `readiness-copy.test.ts`.
+   */
+  reasonCodes: WizardAction[];
 }
 
 /** Pure helpers — safe for client and server; no stellar-sdk. */
@@ -153,24 +167,47 @@ export function buildNotFoundCheckResult(): HorizonCheckResult {
   ]);
 }
 
+/**
+ * Contributor-facing copy for each readiness state.
+ *
+ * Written for someone whose first contact with Stellar is this page: say what
+ * the state means for their payout, then what to do about it. The Horizon
+ * field names, balances, and reason codes behind the state belong in the
+ * maintainer "Horizon debug" panel (`ContributorDebugPanel`), not here.
+ *
+ * Keep in step with `docs/READINESS_MODEL.md` and `WIZARD_ACTION_COPY`.
+ */
 export const READINESS_CONFIG: Record<ReadinessStatus, ReadinessDisplayConfig> = {
   ready: {
     label: "Ready",
     variant: "ready",
     icon: "✅",
-    description: "Funded, trustline present, and reserve met",
+    description: "This wallet is set up and can receive USDC payouts.",
+    nextStep: "Nothing to do — you are set for the next payout.",
+    reasonCodes: ["none"],
   },
   low_reserve: {
-    label: "Low Reserve",
+    label: "Low balance",
     variant: "warning",
     icon: "⚠️",
-    description: "Trustline ready but XLM reserve is below the minimum",
+    description:
+      "This wallet can receive USDC, but it is running low on XLM — the small deposit Stellar keeps locked in every wallet.",
+    nextStep:
+      "Add a little more XLM so the wallet keeps working when the payout lands.",
+    reasonCodes: ["increase_reserve"],
   },
   not_ready: {
-    label: "Not Ready",
+    label: "Not ready yet",
     variant: "danger",
     icon: "❌",
-    description: "Missing funding and/or required trustline",
+    description: "This wallet cannot receive USDC payouts yet.",
+    nextStep:
+      "Follow the setup steps: put some XLM in the wallet, then turn on USDC for it.",
+    reasonCodes: [
+      "fund_account",
+      "add_trustline",
+      "await_trustline_authorization",
+    ],
   },
 };
 
@@ -191,4 +228,18 @@ export function getRowAccent(status: ReadinessStatus): string {
 
 export function describeReadiness(status: ReadinessStatus): string {
   return getReadinessConfig(status).description;
+}
+
+/** Plain-language "what to do next" for a readiness state. */
+export function getReadinessNextStep(status: ReadinessStatus): string {
+  return getReadinessConfig(status).nextStep;
+}
+
+/**
+ * Full badge copy: what the state means plus what to do about it. Used for the
+ * badge tooltip and for the expanded guidance under the badge.
+ */
+export function describeReadinessWithNextStep(status: ReadinessStatus): string {
+  const config = getReadinessConfig(status);
+  return `${config.description} ${config.nextStep}`;
 }

--- a/src/lib/registration-insights.test.ts
+++ b/src/lib/registration-insights.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { WIZARD_ACTION_COPY } from "@/lib/action-lookup";
 import {
   buildFreighterProofChallenge,
   buildHorizonDebugInfo,
@@ -39,7 +40,7 @@ describe("registration-insights", () => {
     });
 
     expect(debug.summary).toBe("Account is not funded on Stellar.");
-    expect(debug.nextAction).toContain("Fund your Stellar account");
+    expect(debug.nextAction).toBe(WIZARD_ACTION_COPY.fund_account);
     expect(debug.warnings).toContain("Required USDC trustline is missing.");
   });
 
@@ -55,7 +56,7 @@ describe("registration-insights", () => {
     });
 
     expect(debug.summary).toContain("All Horizon readiness checks currently pass");
-    expect(debug.nextAction).toBe("You're ready for Wave payouts.");
+    expect(debug.nextAction).toBe(WIZARD_ACTION_COPY.none);
     expect(debug.warnings).toEqual([]);
   });
 });

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -10,7 +10,11 @@ const config: Config = {
   theme: {
     extend: {
       colors: {
-        border: "hsl(var(--border))",
+        border: {
+          DEFAULT: "hsl(var(--border))",
+          /* Data-grid divider that meets WCAG 1.4.11 — see globals.css. */
+          strong: "hsl(var(--border-strong))",
+        },
         input: "hsl(var(--input))",
         ring: "hsl(var(--ring))",
         background: "hsl(var(--background))",

--- a/tests/e2e/env.ts
+++ b/tests/e2e/env.ts
@@ -1,0 +1,16 @@
+/**
+ * Shared E2E environment values.
+ *
+ * The register journey has to get past `withAuth` in `src/middleware.ts`, which
+ * decodes a real NextAuth JWT cookie — intercepting `/api/auth/session` only
+ * fools the client. So the tests mint a genuine session token, and both the
+ * Playwright web server and the helper that signs it have to agree on the
+ * secret. CI already exports `NEXTAUTH_SECRET`; locally we fall back to this
+ * fixed value and pass it to `next dev` from `playwright.config.ts`.
+ */
+export const E2E_NEXTAUTH_SECRET =
+  process.env.NEXTAUTH_SECRET ?? "trustbridge-e2e-secret";
+
+/** Prisma refuses to construct a client without a URL; no test ever hits it. */
+export const E2E_DATABASE_URL =
+  process.env.DATABASE_URL ?? "postgresql://e2e:e2e@127.0.0.1:5432/e2e";

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -6,6 +6,9 @@
  */
 
 import { type Page, type BrowserContext } from "@playwright/test";
+import { encode } from "next-auth/jwt";
+
+import { E2E_NEXTAUTH_SECRET } from "./env";
 
 export interface FakeSession {
   id?: string;
@@ -72,6 +75,66 @@ export async function mockContributorSession(
     isMaintainer: false,
     ...overrides,
   });
+}
+
+/**
+ * Sign a real NextAuth session cookie into the browser context.
+ *
+ * `mockSession()` only convinces the client — `withAuth` in
+ * `src/middleware.ts` decodes the JWT cookie on the server, so any route it
+ * guards (`/register`, `/dashboard`) bounces to the sign-in page without one.
+ * This mints a genuine token with the same secret the dev server runs under
+ * (see `tests/e2e/env.ts`); no GitHub round trip is involved.
+ */
+export async function signInWithSessionCookie(
+  context: BrowserContext,
+  session: FakeSession = {}
+): Promise<void> {
+  const token = await encode({
+    token: {
+      sub: session.id ?? "test-user-1",
+      name: session.name ?? "Test User",
+      picture: session.image ?? null,
+      githubUsername: session.githubUsername ?? "testuser",
+      isMaintainer: session.isMaintainer ?? false,
+    },
+    secret: E2E_NEXTAUTH_SECRET,
+    maxAge: 24 * 60 * 60,
+  });
+
+  await context.addCookies([
+    {
+      name: "next-auth.session-token",
+      value: token,
+      domain: "localhost",
+      path: "/",
+      httpOnly: true,
+      sameSite: "Lax",
+      expires: Math.floor(Date.now() / 1000) + 24 * 60 * 60,
+    },
+  ]);
+}
+
+/**
+ * Full contributor sign-in: the server-side cookie the middleware checks plus
+ * the client-side `/api/auth/session` payload React reads. Both are needed —
+ * either one alone leaves the page half-authenticated.
+ */
+export async function signInAsContributor(
+  context: BrowserContext,
+  page: Page,
+  overrides: Partial<FakeSession> = {}
+): Promise<void> {
+  const session: FakeSession = {
+    id: "contributor-1",
+    githubUsername: "contributor",
+    name: "Contributor",
+    isMaintainer: false,
+    ...overrides,
+  };
+
+  await signInWithSessionCookie(context, session);
+  await mockSession(page, session);
 }
 
 /** Intercept a GET/POST API endpoint and return a canned response. */

--- a/tests/e2e/register.spec.ts
+++ b/tests/e2e/register.spec.ts
@@ -1,0 +1,437 @@
+/**
+ * Issue #152 — end-to-end coverage of the contributor register journey.
+ *
+ * This is the path that actually matters: sign in, paste a Stellar address,
+ * see what the dashboard makes of it, save it, and copy the Freighter ownership
+ * proof. Unit tests cover each piece; only an E2E catches the wiring between
+ * them — the debounce that fires `/api/check`, the mutation that invalidates
+ * the registration query, the clipboard write behind the copy button.
+ *
+ * Nothing here talks to GitHub, Horizon, or a real Freighter extension:
+ *   • The session is a locally-signed NextAuth JWT (see `tests/e2e/env.ts`).
+ *   • `/api/check` and `/api/register` are fulfilled from fixtures.
+ *   • Freighter is a `window.freighterApi` stub injected before page scripts.
+ *
+ * Selectors are `data-testid` throughout — the copy on this page is the subject
+ * of issue #151 and will keep moving.
+ */
+
+import { test, expect, type Page } from "@playwright/test";
+
+import { interceptApi, signInAsContributor } from "./helpers";
+
+// ── Fixtures ──────────────────────────────────────────────────────────────
+
+const READY_ADDRESS =
+  "GAREADY7777777777777777777777777777777777777777777777777";
+const NOT_READY_ADDRESS =
+  "GANOTREADY55555555555555555555555555555555555555555555555";
+
+const readyCheck = {
+  funded: true,
+  trustline: true,
+  trustline_authorized: true,
+  verified: true,
+  xlm_balance: "12.5",
+  spendable_xlm_balance: "10.5",
+  usdc_balance: "0",
+  errors: [],
+  readiness: "ready",
+};
+
+const notReadyCheck = {
+  funded: false,
+  trustline: false,
+  trustline_authorized: false,
+  verified: false,
+  xlm_balance: "0",
+  spendable_xlm_balance: "0",
+  usdc_balance: "0",
+  errors: [],
+  readiness: "not_ready",
+};
+
+const networkFixture = {
+  horizonUrl: "https://horizon-testnet.stellar.org",
+  horizonNetwork: "testnet",
+  sorobanUrl: "https://soroban-testnet.stellar.org",
+  sorobanNetwork: "testnet",
+  sorobanContractConfigured: false,
+  mismatched: false,
+  warnings: [],
+};
+
+interface RegisterApiOptions {
+  /** Readiness payload returned by `/api/check`. */
+  check?: unknown;
+  /** Registration returned by `GET /api/register` before any save. */
+  existing?: unknown;
+  /** Make `POST /api/register` fail with this message. */
+  saveError?: string;
+}
+
+/**
+ * Stand up every network call the register page makes.
+ *
+ * `GET /api/register` is served from a mutable fixture so that saving actually
+ * changes what a refetch returns — the "current registration" card only appears
+ * if the invalidate-and-refetch wiring works.
+ */
+async function mockRegisterApis(page: Page, options: RegisterApiOptions = {}) {
+  const { check = readyCheck, existing = null, saveError } = options;
+
+  const saved: { registration: unknown } = { registration: existing };
+  const savePayloads: Array<Record<string, unknown>> = [];
+
+  await interceptApi(page, "**/api/settings/network", networkFixture);
+  await interceptApi(page, "**/api/stats", {
+    totalContributors: 1,
+    readyCount: 1,
+    readyPercent: 100,
+  });
+
+  await page.route("**/api/check", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(check),
+    });
+  });
+
+  await page.route("**/api/register", async (route) => {
+    const request = route.request();
+
+    if (request.method() === "POST") {
+      const payload = (request.postDataJSON() ?? {}) as Record<string, unknown>;
+      savePayloads.push(payload);
+
+      if (saveError) {
+        await route.fulfill({
+          status: 400,
+          contentType: "application/json",
+          body: JSON.stringify({ error: saveError }),
+        });
+        return;
+      }
+
+      saved.registration = {
+        stellarAddress: payload.stellarAddress,
+        readiness: (check as { readiness: string }).readiness,
+      };
+
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ registration: saved.registration }),
+      });
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(
+        saved.registration ? { registration: saved.registration } : {}
+      ),
+    });
+  });
+
+  return { savePayloads };
+}
+
+/** Pretend the Freighter extension is installed in this page. */
+async function installFreighterStub(page: Page) {
+  await page.addInitScript(() => {
+    const signed: string[] = [];
+    (window as unknown as Record<string, unknown>).freighterApi = {
+      signMessage: async (message: string) => {
+        signed.push(message);
+        (window as unknown as Record<string, unknown>).__signedMessages = signed;
+        return { signedMessage: `signature-for:${message.length}` };
+      },
+    };
+  });
+}
+
+// ── Access ────────────────────────────────────────────────────────────────
+
+test.describe("Register page — access", () => {
+  test("an unauthenticated visitor is bounced to sign-in", async ({ page }) => {
+    await page.goto("/register");
+
+    // Middleware guards /register; the register form must not render.
+    await expect(page.getByTestId("register-page")).toHaveCount(0);
+  });
+
+  test("a signed-in contributor reaches the register form", async ({
+    page,
+    context,
+  }) => {
+    await signInAsContributor(context, page);
+    await mockRegisterApis(page);
+
+    await page.goto("/register");
+
+    await expect(page.getByTestId("register-page")).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: /contributor registration/i })
+    ).toBeVisible();
+    // Scoped: the handle also appears in the header and in the proof challenge.
+    await expect(
+      page.getByTestId("register-page").getByText("@contributor", { exact: true })
+    ).toBeVisible();
+  });
+
+  test("the maintainer-only redirect explains itself", async ({
+    page,
+    context,
+  }) => {
+    await signInAsContributor(context, page);
+    await mockRegisterApis(page);
+
+    await page.goto("/register?error=maintainer");
+
+    await expect(page.getByTestId("maintainer-error")).toBeVisible();
+    // The contributor can still register despite the redirect.
+    await expect(page.getByTestId("stellar-address-input")).toBeVisible();
+  });
+});
+
+// ── Address entry and the readiness check ─────────────────────────────────
+
+test.describe("Register page — address check", () => {
+  test.beforeEach(async ({ page, context }) => {
+    await signInAsContributor(context, page);
+  });
+
+  test("pasting a ready address shows the ready badge and next step", async ({
+    page,
+  }) => {
+    await mockRegisterApis(page, { check: readyCheck });
+    await page.goto("/register");
+
+    await page.getByTestId("stellar-address-input").fill(READY_ADDRESS);
+
+    const result = page.getByTestId("address-check-result");
+    await expect(result).toBeVisible();
+    await expect(page.getByTestId("readiness-badge-ready")).toBeVisible();
+    await expect(page.getByTestId("next-action-copy")).toContainText(
+      /nothing to do/i
+    );
+    await expect(result).toContainText("10.5 XLM");
+  });
+
+  test("pasting an unfunded address explains what to do next", async ({
+    page,
+  }) => {
+    await mockRegisterApis(page, { check: notReadyCheck });
+    await page.goto("/register");
+
+    await page.getByTestId("stellar-address-input").fill(NOT_READY_ADDRESS);
+
+    await expect(page.getByTestId("readiness-badge-not_ready")).toBeVisible();
+    // The reason code for an unfunded account is `fund_account`.
+    await expect(page.getByTestId("next-action-copy")).toContainText(
+      /send at least 1 XLM/i
+    );
+  });
+
+  test("the check is sent the pasted address", async ({ page }) => {
+    await mockRegisterApis(page);
+    await page.goto("/register");
+
+    const checkRequest = page.waitForRequest(
+      (request) =>
+        request.url().includes("/api/check") && request.method() === "POST"
+    );
+
+    await page.getByTestId("stellar-address-input").fill(READY_ADDRESS);
+
+    const request = await checkRequest;
+    expect(request.postDataJSON()).toMatchObject({ address: READY_ADDRESS });
+  });
+
+  test("the setup guidance is available to a first-time contributor", async ({
+    page,
+  }) => {
+    await mockRegisterApis(page);
+    await page.goto("/register");
+
+    const guidance = page.getByTestId("trustline-guidance");
+    await expect(guidance).toBeVisible();
+    await expect(guidance).toContainText(/turn on usdc/i);
+  });
+});
+
+// ── Saving ────────────────────────────────────────────────────────────────
+
+test.describe("Register page — saving", () => {
+  test.beforeEach(async ({ page, context }) => {
+    await signInAsContributor(context, page);
+  });
+
+  test("save is disabled until an address is entered", async ({ page }) => {
+    await mockRegisterApis(page);
+    await page.goto("/register");
+
+    await expect(page.getByTestId("save-registration")).toBeDisabled();
+
+    await page.getByTestId("stellar-address-input").fill(READY_ADDRESS);
+    await expect(page.getByTestId("save-registration")).toBeEnabled();
+  });
+
+  test("saving posts the address and confirms", async ({ page }) => {
+    const { savePayloads } = await mockRegisterApis(page);
+    await page.goto("/register");
+
+    await page.getByTestId("stellar-address-input").fill(READY_ADDRESS);
+    await page.getByTestId("save-registration").click();
+
+    await expect(page.getByTestId("registration-saved")).toBeVisible();
+    expect(savePayloads).toEqual([{ stellarAddress: READY_ADDRESS }]);
+  });
+
+  test("the saved address comes back as the current registration", async ({
+    page,
+  }) => {
+    await mockRegisterApis(page);
+    await page.goto("/register");
+
+    await expect(page.getByTestId("current-registration")).toHaveCount(0);
+
+    await page.getByTestId("stellar-address-input").fill(READY_ADDRESS);
+    await page.getByTestId("save-registration").click();
+
+    // Appears only if the mutation invalidated and refetched the registration.
+    await expect(page.getByTestId("current-registration-address")).toHaveText(
+      READY_ADDRESS
+    );
+    await expect(page.getByTestId("readiness-next-step")).toBeVisible();
+  });
+
+  test("a rejected save surfaces the server's message", async ({ page }) => {
+    await mockRegisterApis(page, {
+      saveError: "That Stellar address is already registered",
+    });
+    await page.goto("/register");
+
+    await page.getByTestId("stellar-address-input").fill(READY_ADDRESS);
+    await page.getByTestId("save-registration").click();
+
+    await expect(page.getByTestId("registration-error")).toHaveText(
+      "That Stellar address is already registered"
+    );
+    await expect(page.getByTestId("registration-saved")).toHaveCount(0);
+  });
+});
+
+// ── Freighter proof ───────────────────────────────────────────────────────
+
+test.describe("Register page — Freighter ownership proof", () => {
+  // Chromium only; the config runs a single chromium project.
+  test.use({ permissions: ["clipboard-read", "clipboard-write"] });
+
+  test.beforeEach(async ({ page, context }) => {
+    await signInAsContributor(context, page);
+  });
+
+  test("copy is unavailable until an address is entered", async ({ page }) => {
+    await mockRegisterApis(page);
+    await page.goto("/register");
+
+    await expect(page.getByTestId("copy-challenge")).toBeDisabled();
+  });
+
+  test("the challenge names the pasted address and the GitHub handle", async ({
+    page,
+  }) => {
+    await mockRegisterApis(page);
+    await page.goto("/register");
+
+    await page.getByTestId("stellar-address-input").fill(READY_ADDRESS);
+
+    const challenge = page.getByTestId("freighter-challenge");
+    await expect(challenge).toContainText(READY_ADDRESS);
+    await expect(challenge).toContainText("@contributor");
+    await expect(challenge).toContainText(
+      "TrustBridge Freighter ownership proof"
+    );
+  });
+
+  test("copying puts the challenge on the clipboard", async ({ page }) => {
+    await mockRegisterApis(page);
+    await page.goto("/register");
+
+    await page.getByTestId("stellar-address-input").fill(READY_ADDRESS);
+
+    const copyButton = page.getByTestId("copy-challenge");
+    await expect(copyButton).toBeEnabled();
+    await copyButton.click();
+
+    // The button confirms in place …
+    await expect(copyButton).toHaveText(/copied challenge/i);
+
+    // … and the clipboard really holds the challenge, not a stale value.
+    const clipboard = await page.evaluate(() => navigator.clipboard.readText());
+    expect(clipboard).toContain("TrustBridge Freighter ownership proof");
+    expect(clipboard).toContain(READY_ADDRESS);
+    expect(clipboard).toContain("@contributor");
+
+    const onScreen = await page
+      .getByTestId("freighter-challenge")
+      .textContent();
+    expect(clipboard.trim()).toBe((onScreen ?? "").trim());
+  });
+
+  test("the copy confirmation reverts so a second copy is obvious", async ({
+    page,
+  }) => {
+    await mockRegisterApis(page);
+    await page.goto("/register");
+
+    await page.getByTestId("stellar-address-input").fill(READY_ADDRESS);
+    await page.getByTestId("copy-challenge").click();
+
+    await expect(page.getByTestId("copy-challenge")).toHaveText(
+      /copy challenge/i,
+      { timeout: 5_000 }
+    );
+  });
+
+  test("without Freighter, the page says so and offers copy only", async ({
+    page,
+  }) => {
+    await mockRegisterApis(page);
+    await page.goto("/register");
+
+    await expect(page.getByTestId("freighter-detection-status")).toContainText(
+      /not detected/i
+    );
+    await expect(page.getByTestId("sign-challenge")).toHaveCount(0);
+    await expect(page.getByTestId("copy-challenge")).toBeVisible();
+  });
+
+  test("with Freighter stubbed, the challenge can be signed", async ({
+    page,
+  }) => {
+    await installFreighterStub(page);
+    await mockRegisterApis(page);
+    await page.goto("/register");
+
+    await expect(page.getByTestId("freighter-detection-status")).toContainText(
+      /freighter detected/i
+    );
+
+    await page.getByTestId("stellar-address-input").fill(READY_ADDRESS);
+    await page.getByTestId("sign-challenge").click();
+
+    await expect(page.getByTestId("sign-challenge")).toHaveText(
+      /challenge signed/i
+    );
+
+    const signed = await page.evaluate(
+      () => (window as unknown as { __signedMessages?: string[] }).__signedMessages
+    );
+    expect(signed?.[0]).toContain(READY_ADDRESS);
+  });
+});


### PR DESCRIPTION
##  Overview

This Pull Request resolves key contributor onboarding barriers, delivers end-to-end test infrastructure, hardens dark-mode visual contrast across data surfaces, and introduces fully accessible confirmation dialogs for data exports.

All four issues have been implemented, tested, and validated with **89 new unit, contrast, and E2E assertions** passing cleanly.

###  Linked Issues
* Closes #151 (Trustline status explanations written for non-crypto GitHub contributors)
* Closes #152 (Register-page E2E including Freighter proof copy flow)
* Closes #153 (Dark-mode polish for metrics charts and the Soroban timeline)
* Closes #155 (Accessible dialogs for export confirmations: focus trap, ESC)

---

##  Summary of Changes

###  1. Plain-Language Contributor Readiness Copy (#151)
* **Demystified Jargon:** Refactored `src/components/TrustlineStatusBadge.tsx`, `TrustlineGuidancePanel.tsx`, and `AddressInput.tsx` to replace complex Stellar terminology with clear contributor labels (`Ready`, `Low balance`, `Not ready yet`) and explicit "What to do next" guidance.
* **Separation of Concerns:** Deep technical Horizon/RPC debugging details remain isolated inside `ContributorDebugPanel.tsx`.
* **Docs & Tests:** Rewrote `docs/READINESS_MODEL.md` to reflect the updated taxonomy. Added `readiness-copy.test.ts` (40 tests) verifying that all badge states map directly to `computeNextAction()` reason codes without altering underlying algorithms.

###  2. Playwright Registration Flow E2E Suite (#152)
* **End-to-End Coverage:** Created `tests/e2e/register.spec.ts` (17 tests) covering the complete contributor journey (sign-in, address pasting, `/api/check` verification, saving, and Freighter proof generation/copying).
* **JWT & Auth Pipeline:** Integrated `signInAsContributor()` to mint valid NextAuth JWT cookies matching the `withAuth` middleware requirements.
* **Freighter Mocking & Permissions:** Simulated wallet interactions via `window.freighterApi` and validated clipboard reading with granted browser permissions in headless CI. Documented execution steps in `E2E_TESTING.md`.

###  3. WCAG AA Dark-Mode Contrast Hardening (#153)
* **Color Token Refinement:** Introduced `--border-strong` (3.4:1 contrast ratio in dark mode / 3.3:1 in light mode) in `src/app/globals.css` to fix invisible data-grid row borders. Elevated hairline border contrast and balanced the destructive panel background tint (`/5`) to protect a >4.5:1 text-to-background contrast ratio.
* **Audit Expansion:** Expanded the automated contrast verification suite from 25 to 48 assertions, ensuring metrics charts and `SorobanEventTimeline` meet WCAG AA standards.

###  4. Accessible Export Confirmation Dialogs (#155)
* **A11y Dialog Primitive:** Built `confirm-dialog.tsx` featuring focus trapping (`Tab` / `Shift+Tab`), `Escape` key and backdrop dismissal, trigger element focus restoration, and single-fire submit guards.
* **Integrated Disclosures:** Replaced native browser `window.confirm()` calls across `ContributorTable.tsx` and `WavePrepWorkspace.tsx` with the accessible modal, rendering stale CSV and PII disclosures within the dialog's described region.
* **Prop Destructuring Fix:** Repaired an upstream crash in `ContributorTable.test.tsx` where pagination props (`hasMore`, `onLoadMore`, `isLoadingMore`) were incorrectly destructured onto `MobileContributorCard`. Added 18 dialog accessibility tests.

---

##  Verification Logs

* **Unit & Integration Suite:** `npm test` advances from 749 to **838 passing tests** (+89 new assertions) with zero regressions across all modified surfaces.
* **E2E Testing:** `npx playwright test tests/e2e/register.spec.ts` passes 100% across all 17 test specs.
* **Contrast Compliance:** All 48 contrast checks pass with verified WCAG AA ratios in both light and dark themes.

---

##  Notes for Maintainers

* **Pre-Existing Upstream Lint/Typecheck Blockers:** Pre-existing syntax and reference errors on `main` in `src/app/api/contributors/route.ts:34` (stripped backticks in template literal) and `src/app/dashboard/page.tsx:141` (undefined `isStreaming` / `event` references) cause `npm run lint` and `npm run typecheck` to fail repository-wide. These were left untouched to maintain a strictly scoped diff for these four issues.