### PR TITLE
Fix unescaped quotes breaking parse of WalletInstallStepper.tsx

### DIFF
--- a/src/components/WalletInstallStepper.tsx
+++ b/src/components/WalletInstallStepper.tsx
@@ -163,7 +163,7 @@ const WALLETS: WalletConfig[] = [
       {
         label: "Create or import a wallet",
         description:
-          "Open LOBSTR and tap "Create account" or "Import with secret key / recovery phrase". Back up your recovery phrase before continuing.",
+          'Open LOBSTR and tap "Create account" or "Import with secret key / recovery phrase". Back up your recovery phrase before continuing.',
       },
       {
         label: "Fund with XLM",
@@ -241,7 +241,7 @@ const WALLETS: WalletConfig[] = [
       {
         label: "Create or import a wallet",
         description:
-          "Open xBull and choose "Create a new wallet" or "Import wallet". Safely record your passphrase before moving on.",
+          'Open xBull and choose "Create a new wallet" or "Import wallet". Safely record your passphrase before moving on.',
       },
       {
         label: "Fund with XLM",


### PR DESCRIPTION
## Summary
- Two step descriptions in `WalletInstallStepper.tsx` (LOBSTR and xBull "Create or import a wallet" steps) use double-quoted string literals with unescaped inner double quotes around phrases like `"Create account"` / `"Import wallet"`.
- This is a hard JS/TS syntax error — it breaks parsing of the whole file, which breaks `tsc --noEmit` and `next build` for the entire app, since `WalletInstallStepper` is rendered on `/register`.
- Fix: switch both strings to single-quoted so the inner double-quoted phrases don't need escaping. No other changes.

## Why this is separate from the other PRs
While implementing #136, #137, #141, and #142 I found this pre-existing bug already on `main` blocking typecheck/build repo-wide, unrelated to any of those issues. Filing it standalone so it can be reviewed and merged quickly on its own; each of the four issue PRs also carries this same one-line fix as a prerequisite commit so their own CI can pass independently until this merges.

## Test plan
- [ ] `npx tsc --noEmit` no longer errors on this file
- [ ] `npm run build` succeeds