### PR TITLE
Honor prefers-reduced-motion for WaveReadinessBar (#141)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -77,3 +77,27 @@
     text-wrap: balance;
   }
 }
+
+/*
+ * Respect prefers-reduced-motion sitewide (issue #141). Collapses
+ * animation/transition durations to effectively zero so motion-sensitive
+ * users don't get sweeping transitions (e.g. WaveReadinessBar's fill bar).
+ * `.animate-spin` is explicitly exempted below — Loader2 spinners communicate
+ * genuine async/loading state, not decorative motion, and freezing them would
+ * make the UI look stuck rather than accessible.
+ */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+
+  .animate-spin {
+    animation-duration: 1s !important;
+    animation-iteration-count: infinite !important;
+  }
+}

--- a/src/components/WalletInstallStepper.tsx
+++ b/src/components/WalletInstallStepper.tsx
@@ -163,7 +163,7 @@ const WALLETS: WalletConfig[] = [
       {
         label: "Create or import a wallet",
         description:
-          "Open LOBSTR and tap "Create account" or "Import with secret key / recovery phrase". Back up your recovery phrase before continuing.",
+          'Open LOBSTR and tap "Create account" or "Import with secret key / recovery phrase". Back up your recovery phrase before continuing.',
       },
       {
         label: "Fund with XLM",
@@ -241,7 +241,7 @@ const WALLETS: WalletConfig[] = [
       {
         label: "Create or import a wallet",
         description:
-          "Open xBull and choose "Create a new wallet" or "Import wallet". Safely record your passphrase before moving on.",
+          'Open xBull and choose "Create a new wallet" or "Import wallet". Safely record your passphrase before moving on.',
       },
       {
         label: "Fund with XLM",

--- a/src/components/WaveReadinessBar.test.tsx
+++ b/src/components/WaveReadinessBar.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { WaveReadinessBar } from "@/components/WaveReadinessBar";
+
+describe("WaveReadinessBar component", () => {
+  it("renders ready/total counts and computed percent", () => {
+    render(<WaveReadinessBar readyCount={3} totalCount={4} />);
+
+    expect(screen.getByText("Wave payout readiness")).toBeInTheDocument();
+    expect(screen.getByText("3/4 ready (75%)")).toBeInTheDocument();
+  });
+
+  it("sets the fill bar width to the computed percent", () => {
+    render(<WaveReadinessBar readyCount={1} totalCount={2} />);
+
+    const fill = screen.getByTestId("wave-readiness-fill");
+    expect(fill).toHaveStyle({ width: "50%" });
+  });
+
+  it("renders zero width when there are no contributors", () => {
+    render(<WaveReadinessBar readyCount={0} totalCount={0} />);
+
+    expect(screen.getByText("0/0 ready (0%)")).toBeInTheDocument();
+    const fill = screen.getByTestId("wave-readiness-fill");
+    expect(fill).toHaveStyle({ width: "0%" });
+  });
+
+  it("honors prefers-reduced-motion via the motion-reduce transition-none class", () => {
+    render(<WaveReadinessBar readyCount={2} totalCount={5} />);
+
+    const fill = screen.getByTestId("wave-readiness-fill");
+    // Base transition is preserved for users without the preference...
+    expect(fill).toHaveClass("transition-all");
+    expect(fill).toHaveClass("duration-500");
+    // ...but is disabled sitewide under prefers-reduced-motion via this variant.
+    expect(fill).toHaveClass("motion-reduce:transition-none");
+  });
+
+  it("does not remove the readiness bar itself", () => {
+    const { container } = render(
+      <WaveReadinessBar readyCount={2} totalCount={5} />
+    );
+
+    // The track/bar wrapper should still be present, motion is the only thing gated.
+    expect(container.querySelector(".rounded-full.bg-muted")).toBeTruthy();
+  });
+});

--- a/src/components/WaveReadinessBar.tsx
+++ b/src/components/WaveReadinessBar.tsx
@@ -25,7 +25,8 @@ export function WaveReadinessBar({
       </div>
       <div className="h-3 w-full overflow-hidden rounded-full bg-muted">
         <div
-          className="h-full rounded-full bg-gradient-to-r from-stellar-purple to-stellar-cyan transition-all duration-500"
+          data-testid="wave-readiness-fill"
+          className="h-full rounded-full bg-gradient-to-r from-stellar-purple to-stellar-cyan transition-all duration-500 motion-reduce:transition-none"
           style={{ width: `${percent}%` }}
         />
       </div>


### PR DESCRIPTION
Closes #141

## Summary
- `src/app/globals.css`: adds a sitewide `@media (prefers-reduced-motion: reduce)` rule that collapses `animation-duration`/`transition-duration`/`scroll-behavior` to near-zero, with an explicit exception restoring normal `.animate-spin` animation so `Loader2` loading spinners keep working (they signal genuine async activity, not decorative motion — freezing them would look broken rather than accessible).
- `src/components/WaveReadinessBar.tsx`: adds `motion-reduce:transition-none` alongside the existing `transition-all duration-500` on the fill bar. The bar itself, its layout, and dark-mode colors are untouched — only the transition is gated.
- New `src/components/WaveReadinessBar.test.tsx` covering percent/width rendering and the presence of the motion-reduce class.

## Scope note: toasts
I grepped the entire `src/` tree for "toast" (case-insensitive) and found zero matches — there is no toast library or custom toast component anywhere in this codebase today. The issue's "toasts" reference doesn't map to any real code yet, so that half is necessarily out of scope until a toast system exists (building one from scratch would also cross the issue's own "Out: A full a11y rewrite" line). The global `prefers-reduced-motion` CSS rule will automatically cover any future toast component's transitions once one is added.

## Also included
A one-line prerequisite fix for a pre-existing, unrelated syntax error in `WalletInstallStepper.tsx` (unescaped quotes) that breaks typecheck/build repo-wide — filed standalone in #230 as well, since it predates this branch and blocks every PR's CI.

## PR checklist (from the issue)
- [x] Reduced motion
- [ ] Screenshots optional (not included — text/CSS-only change)

## Test plan
- [ ] `npm test`
- [ ] `npm run lint`