### PR TITLE
Add distinct progress states to AddressInput checks (#136)

### DIFF
--- a/src/components/AddressInput.test.tsx
+++ b/src/components/AddressInput.test.tsx
@@ -19,6 +19,41 @@ vi.mock("qrcode", () => ({
   },
 }));
 
+const readyBody = {
+  funded: true,
+  trustline: true,
+  trustline_authorized: true,
+  verified: false,
+  xlm_balance: "5",
+  spendable_xlm_balance: "4",
+  usdc_balance: "0",
+  errors: [],
+  readiness: "ready",
+};
+
+/** Build a minimal `Response`-shaped mock for `global.fetch`. */
+function mockResponse({
+  status = 200,
+  ok = status >= 200 && status < 300,
+  body,
+  retryAfter,
+}: {
+  status?: number;
+  ok?: boolean;
+  body: unknown;
+  retryAfter?: string;
+}) {
+  return {
+    status,
+    ok,
+    json: async () => body,
+    headers: {
+      get: (name: string) =>
+        name.toLowerCase() === "retry-after" ? (retryAfter ?? null) : null,
+    },
+  };
+}
+
 describe("AddressInput QR and copy", () => {
   afterEach(() => {
     cleanup();
@@ -31,19 +66,11 @@ describe("AddressInput QR and copy", () => {
         writeText: vi.fn().mockResolvedValue(undefined),
       },
     });
-    global.fetch = vi.fn().mockResolvedValue({
-      json: async () => ({
-        funded: true,
-        trustline: true,
-        trustline_authorized: true,
-        verified: false,
-        xlm_balance: "5",
-        spendable_xlm_balance: "4",
-        usdc_balance: "0",
-        errors: [],
-        readiness: "ready",
-      }),
-    }) as unknown as typeof fetch;
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue(
+        mockResponse({ status: 200, body: readyBody })
+      ) as unknown as typeof fetch;
   });
 
   it("does not show QR or enable copy for invalid addresses", () => {
@@ -73,6 +100,140 @@ describe("AddressInput QR and copy", () => {
       expect(screen.getByTestId("copy-address")).toHaveTextContent("Copied");
       expect(screen.getByTestId("copy-address-status")).toHaveTextContent(
         /Address copied to clipboard/i
+      );
+    });
+  });
+
+  it("shows the ready readiness result once the check resolves", async () => {
+    render(<AddressInput value={VALID} onChange={() => {}} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("address-check-result")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("readiness-badge-ready")).toBeInTheDocument();
+  });
+});
+
+describe("AddressInput check progress states", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.assign(navigator, {
+      clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+  });
+
+  it("shows a rate-limited message with retry-after seconds on a 429", async () => {
+    global.fetch = vi.fn().mockResolvedValue(
+      mockResponse({
+        status: 429,
+        ok: false,
+        body: { errors: ["Rate limit exceeded. Please try again later."] },
+        retryAfter: "42",
+      })
+    ) as unknown as typeof fetch;
+
+    render(<AddressInput value={VALID} onChange={() => {}} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("address-check-status")).toHaveTextContent(
+        /try again in 42s/i
+      );
+    });
+    // The generic result block (readiness badge etc.) must not render for
+    // a rate-limited outcome — it isn't a HorizonCheckResult.
+    expect(
+      screen.queryByTestId("address-check-result")
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows a circuit-open message for a 200 response with a transient Horizon error", async () => {
+    global.fetch = vi.fn().mockResolvedValue(
+      mockResponse({
+        status: 200,
+        body: {
+          funded: false,
+          trustline: false,
+          trustline_authorized: false,
+          verified: false,
+          xlm_balance: "0",
+          spendable_xlm_balance: "0",
+          usdc_balance: "0",
+          errors: [
+            "Horizon is temporarily unavailable. Please try again later.",
+          ],
+          readiness: "not_ready",
+        },
+      })
+    ) as unknown as typeof fetch;
+
+    render(<AddressInput value={VALID} onChange={() => {}} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("address-check-status")).toHaveTextContent(
+        /temporarily unavailable/i
+      );
+    });
+    expect(
+      screen.queryByTestId("address-check-result")
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows a timeout message when the fetch is aborted", async () => {
+    const abortError = Object.assign(new Error("The operation was aborted."), {
+      name: "AbortError",
+    });
+    global.fetch = vi.fn().mockRejectedValue(abortError) as unknown as typeof fetch;
+
+    render(<AddressInput value={VALID} onChange={() => {}} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("address-check-status")).toHaveTextContent(
+        /timed out/i
+      );
+    });
+  });
+
+  it("shows a generic error message on a plain network failure", async () => {
+    global.fetch = vi
+      .fn()
+      .mockRejectedValue(new TypeError("Failed to fetch")) as unknown as typeof fetch;
+
+    render(<AddressInput value={VALID} onChange={() => {}} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("address-check-status")).toHaveTextContent(
+        /unable to reach validation service/i
+      );
+    });
+  });
+
+  it("marks the input aria-busy while a check is in flight", async () => {
+    let resolveFetch: (value: unknown) => void = () => {};
+    global.fetch = vi.fn().mockReturnValue(
+      new Promise((resolve) => {
+        resolveFetch = resolve;
+      })
+    ) as unknown as typeof fetch;
+
+    render(<AddressInput value={VALID} onChange={() => {}} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("stellar-address-input")).toHaveAttribute(
+        "aria-busy",
+        "true"
+      );
+    });
+
+    resolveFetch(mockResponse({ status: 200, body: readyBody }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("stellar-address-input")).toHaveAttribute(
+        "aria-busy",
+        "false"
       );
     });
   });

--- a/src/components/AddressInput.tsx
+++ b/src/components/AddressInput.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Check, Copy, Loader2 } from "lucide-react";
 
 import { AddressQr } from "@/components/AddressQr";
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { computeNextAction, WIZARD_ACTION_COPY } from "@/lib/action-lookup";
+import { checkAddressViaApi } from "@/lib/check-api-client";
 import { isValidGAddress, normalizeGAddress } from "@/lib/stellar-address";
 import { cn } from "@/lib/utils";
 import type { HorizonCheckResult } from "@/types";
@@ -20,17 +21,42 @@ interface AddressInputProps {
   className?: string;
 }
 
+/**
+ * Distinct states the debounced Horizon check can be in. `checking` covers
+ * every in-flight attempt (there's no separate "retrying" state client-side
+ * — retries happen server-side inside `checkStellarAddress`/the circuit
+ * breaker and are invisible to the browser); the other non-idle states are
+ * terminal outcomes of the most recent request.
+ */
+type CheckState =
+  | { status: "idle" }
+  | { status: "checking" }
+  | { status: "result"; result: HorizonCheckResult }
+  | {
+      status: "rate_limited";
+      retryAfterSeconds: number | null;
+      errors: string[];
+    }
+  | { status: "circuit_open"; errors: string[] }
+  | { status: "timeout" }
+  | { status: "error"; errors: string[] };
+
 export function AddressInput({
   value,
   onChange,
   disabled,
   className,
 }: AddressInputProps) {
-  const [checking, setChecking] = useState(false);
-  const [result, setResult] = useState<HorizonCheckResult | null>(null);
+  const [checkState, setCheckState] = useState<CheckState>({ status: "idle" });
   const [debouncedValue, setDebouncedValue] = useState(value);
   const [copied, setCopied] = useState(false);
   const [copyFailed, setCopyFailed] = useState(false);
+
+  // Guards against debounce/network races: if the user keeps typing, a
+  // later checkAddress() call can be kicked off before an earlier one's
+  // fetch (or its timeout) resolves. Only the response matching the most
+  // recently *started* request is applied.
+  const requestIdRef = useRef(0);
 
   const normalized = normalizeGAddress(value);
   const addressValid = isValidGAddress(normalized);
@@ -41,40 +67,55 @@ export function AddressInput({
   }, [value]);
 
   const checkAddress = useCallback(async (address: string) => {
+    const requestId = ++requestIdRef.current;
+
     if (!address.trim()) {
-      setResult(null);
+      setCheckState({ status: "idle" });
       return;
     }
 
-    setChecking(true);
-    try {
-      const response = await fetch("/api/check", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ address }),
-      });
-      const data = (await response.json()) as HorizonCheckResult;
-      setResult(data);
-    } catch {
-      setResult({
-        funded: false,
-        trustline: false,
-        trustline_authorized: false,
-        verified: false,
-        xlm_balance: "0",
-        spendable_xlm_balance: "0",
-        usdc_balance: "0",
-        errors: ["Unable to reach validation service"],
-        readiness: "not_ready",
-      });
-    } finally {
-      setChecking(false);
+    setCheckState({ status: "checking" });
+    const outcome = await checkAddressViaApi(address);
+
+    // A newer check has started since this one was kicked off — drop this
+    // (now stale) response rather than clobbering fresher state.
+    if (requestIdRef.current !== requestId) return;
+
+    switch (outcome.kind) {
+      case "ok":
+        setCheckState({ status: "result", result: outcome.result });
+        break;
+      case "rate_limited":
+        setCheckState({
+          status: "rate_limited",
+          retryAfterSeconds: outcome.retryAfterSeconds,
+          errors: outcome.errors,
+        });
+        break;
+      case "circuit_open":
+        setCheckState({ status: "circuit_open", errors: outcome.errors });
+        break;
+      case "timeout":
+        setCheckState({ status: "timeout" });
+        break;
+      case "network_error":
+        setCheckState({
+          status: "error",
+          errors: ["Unable to reach validation service"],
+        });
+        break;
+      case "error":
+        setCheckState({ status: "error", errors: outcome.errors });
+        break;
     }
   }, []);
 
   useEffect(() => {
     checkAddress(debouncedValue);
   }, [debouncedValue, checkAddress]);
+
+  const isChecking = checkState.status === "checking";
+  const result = checkState.status === "result" ? checkState.result : null;
 
   async function copyAddress() {
     if (!addressValid) return;
@@ -114,9 +155,13 @@ export function AddressInput({
               spellCheck={false}
               autoComplete="off"
               aria-describedby="stellar-address-help"
+              aria-busy={isChecking}
             />
-            {checking && (
-              <Loader2 className="absolute right-3 top-2.5 h-5 w-5 animate-spin text-muted-foreground" />
+            {isChecking && (
+              <Loader2
+                className="absolute right-3 top-2.5 h-5 w-5 animate-spin text-muted-foreground"
+                aria-hidden="true"
+              />
             )}
           </div>
           <Button
@@ -174,6 +219,38 @@ export function AddressInput({
             and QR. Typos here often cause PAYMENT_NO_TRUST failures.
           </p>
         )}
+        <p
+          className={cn(
+            "text-xs",
+            checkState.status === "rate_limited" ||
+              checkState.status === "timeout" ||
+              checkState.status === "error"
+              ? "text-destructive"
+              : checkState.status === "circuit_open"
+                ? "text-amber-700 dark:text-amber-300"
+                : "text-muted-foreground",
+            checkState.status === "idle" || checkState.status === "result"
+              ? "sr-only"
+              : undefined
+          )}
+          role="status"
+          aria-live="polite"
+          aria-busy={isChecking}
+          data-testid="address-check-status"
+        >
+          {checkState.status === "checking" &&
+            "Checking this address with Horizon…"}
+          {checkState.status === "rate_limited" &&
+            (checkState.retryAfterSeconds
+              ? `Too many checks in a row. Try again in ${checkState.retryAfterSeconds}s.`
+              : "Too many checks in a row. Please wait a moment and try again.")}
+          {checkState.status === "circuit_open" &&
+            "Horizon is temporarily unavailable. We'll keep this address ready to recheck — please try again shortly."}
+          {checkState.status === "timeout" &&
+            "The check timed out. Horizon may be slow right now — try again in a moment."}
+          {checkState.status === "error" &&
+            (checkState.errors[0] ?? "Unable to check this address right now.")}
+        </p>
       </div>
 
       {addressValid && (

--- a/src/components/WalletInstallStepper.tsx
+++ b/src/components/WalletInstallStepper.tsx
@@ -163,7 +163,7 @@ const WALLETS: WalletConfig[] = [
       {
         label: "Create or import a wallet",
         description:
-          "Open LOBSTR and tap "Create account" or "Import with secret key / recovery phrase". Back up your recovery phrase before continuing.",
+          'Open LOBSTR and tap "Create account" or "Import with secret key / recovery phrase". Back up your recovery phrase before continuing.',
       },
       {
         label: "Fund with XLM",
@@ -241,7 +241,7 @@ const WALLETS: WalletConfig[] = [
       {
         label: "Create or import a wallet",
         description:
-          "Open xBull and choose "Create a new wallet" or "Import wallet". Safely record your passphrase before moving on.",
+          'Open xBull and choose "Create a new wallet" or "Import wallet". Safely record your passphrase before moving on.',
       },
       {
         label: "Fund with XLM",

--- a/src/lib/check-api-client.test.ts
+++ b/src/lib/check-api-client.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { checkAddressViaApi } from "@/lib/check-api-client";
+
+function mockResponse({
+  status = 200,
+  ok = status >= 200 && status < 300,
+  body,
+  retryAfter,
+}: {
+  status?: number;
+  ok?: boolean;
+  body: unknown;
+  retryAfter?: string;
+}) {
+  return {
+    status,
+    ok,
+    json: async () => body,
+    headers: {
+      get: (name: string) =>
+        name.toLowerCase() === "retry-after" ? (retryAfter ?? null) : null,
+    },
+  };
+}
+
+const readyBody = {
+  funded: true,
+  trustline: true,
+  trustline_authorized: true,
+  verified: true,
+  xlm_balance: "5",
+  spendable_xlm_balance: "4",
+  usdc_balance: "0",
+  errors: [],
+  readiness: "ready",
+};
+
+describe("checkAddressViaApi", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns an ok outcome for a normal successful result", async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue(mockResponse({ status: 200, body: readyBody })) as unknown as typeof fetch;
+
+    const outcome = await checkAddressViaApi("GADDRESS");
+    expect(outcome).toEqual({ kind: "ok", result: readyBody });
+  });
+
+  it("returns a rate_limited outcome for a 429 with Retry-After", async () => {
+    global.fetch = vi.fn().mockResolvedValue(
+      mockResponse({
+        status: 429,
+        ok: false,
+        body: { errors: ["Rate limit exceeded. Please try again later."] },
+        retryAfter: "17",
+      })
+    ) as unknown as typeof fetch;
+
+    const outcome = await checkAddressViaApi("GADDRESS");
+    expect(outcome).toEqual({
+      kind: "rate_limited",
+      retryAfterSeconds: 17,
+      errors: ["Rate limit exceeded. Please try again later."],
+    });
+  });
+
+  it("returns rate_limited with a null retryAfterSeconds when the header is missing", async () => {
+    global.fetch = vi.fn().mockResolvedValue(
+      mockResponse({
+        status: 429,
+        ok: false,
+        body: { errors: ["Rate limit exceeded. Please try again later."] },
+      })
+    ) as unknown as typeof fetch;
+
+    const outcome = await checkAddressViaApi("GADDRESS");
+    expect(outcome.kind).toBe("rate_limited");
+    if (outcome.kind === "rate_limited") {
+      expect(outcome.retryAfterSeconds).toBeNull();
+    }
+  });
+
+  it("returns a circuit_open outcome for a 200 with a temporarily-unavailable error", async () => {
+    global.fetch = vi.fn().mockResolvedValue(
+      mockResponse({
+        status: 200,
+        body: {
+          ...readyBody,
+          readiness: "not_ready",
+          errors: [
+            "Horizon is temporarily unavailable. Please try again later.",
+          ],
+        },
+      })
+    ) as unknown as typeof fetch;
+
+    const outcome = await checkAddressViaApi("GADDRESS");
+    expect(outcome.kind).toBe("circuit_open");
+  });
+
+  it("returns a circuit_open outcome for a 200 with a generic Horizon error prefix", async () => {
+    global.fetch = vi.fn().mockResolvedValue(
+      mockResponse({
+        status: 200,
+        body: {
+          ...readyBody,
+          readiness: "not_ready",
+          errors: ["Horizon error: connection reset"],
+        },
+      })
+    ) as unknown as typeof fetch;
+
+    const outcome = await checkAddressViaApi("GADDRESS");
+    expect(outcome.kind).toBe("circuit_open");
+  });
+
+  it("returns a generic error outcome for a non-2xx, non-429 status", async () => {
+    global.fetch = vi.fn().mockResolvedValue(
+      mockResponse({
+        status: 500,
+        ok: false,
+        body: { errors: ["Failed to check address"] },
+      })
+    ) as unknown as typeof fetch;
+
+    const outcome = await checkAddressViaApi("GADDRESS");
+    expect(outcome).toEqual({
+      kind: "error",
+      status: 500,
+      errors: ["Failed to check address"],
+    });
+  });
+
+  it("returns a timeout outcome when the fetch is aborted", async () => {
+    const abortError = Object.assign(new Error("The operation was aborted."), {
+      name: "AbortError",
+    });
+    global.fetch = vi.fn().mockRejectedValue(abortError) as unknown as typeof fetch;
+
+    const outcome = await checkAddressViaApi("GADDRESS");
+    expect(outcome).toEqual({ kind: "timeout" });
+  });
+
+  it("returns a network_error outcome for other fetch failures", async () => {
+    global.fetch = vi
+      .fn()
+      .mockRejectedValue(new TypeError("Failed to fetch")) as unknown as typeof fetch;
+
+    const outcome = await checkAddressViaApi("GADDRESS");
+    expect(outcome).toEqual({ kind: "network_error" });
+  });
+});

--- a/src/lib/check-api-client.ts
+++ b/src/lib/check-api-client.ts
@@ -1,0 +1,127 @@
+import type { HorizonCheckResult } from "@/types";
+
+/**
+ * Client-side wrapper around `POST /api/check`.
+ *
+ * The route itself already encodes several distinct outcomes (see
+ * `src/app/api/check/route.ts`), but they arrive over the wire in
+ * inconsistent shapes:
+ *  - Rate limiting is a genuine HTTP 429 with a `Retry-After` header.
+ *  - A circuit-breaker-open / transient Horizon failure is still HTTP 200,
+ *    with a normal `HorizonCheckResult` body whose `errors` array contains a
+ *    recognizable string (`"...temporarily unavailable..."` or a
+ *    `"Horizon error: ..."` prefix). There is no dedicated status code or
+ *    field for this today, and changing that is out of scope for this
+ *    change — we only need to recognize the existing convention.
+ *  - Anything else non-2xx is a generic error.
+ *  - The request itself can hang (Horizon retries/circuit breaker can sit
+ *    for a while) — there is no client-side timeout today, so we add one
+ *    here via `AbortController`.
+ *
+ * This helper normalizes all of that into a single discriminated union so
+ * UI code can `switch` on `outcome.kind` instead of re-deriving these rules.
+ */
+
+/** How long to wait for `/api/check` before treating the request as timed out. */
+export const CHECK_TIMEOUT_MS = 10_000;
+
+export type CheckOutcome =
+  | { kind: "ok"; result: HorizonCheckResult }
+  | { kind: "rate_limited"; retryAfterSeconds: number | null; errors: string[] }
+  | { kind: "circuit_open"; errors: string[] }
+  | { kind: "timeout" }
+  | { kind: "network_error" }
+  | { kind: "error"; status: number; errors: string[] };
+
+/**
+ * True when a successful (HTTP 200) `HorizonCheckResult`'s `errors` match the
+ * known transient-Horizon-failure conventions emitted by `src/lib/horizon.ts`
+ * (circuit breaker open, or a generic wrapped Horizon error).
+ */
+function isTransientHorizonError(errors: string[] | undefined): boolean {
+  if (!errors || errors.length === 0) return false;
+  return errors.some(
+    (error) =>
+      error.includes("temporarily unavailable") ||
+      error.startsWith("Horizon error:")
+  );
+}
+
+function parseRetryAfter(response: Response): number | null {
+  const header = response.headers.get("Retry-After");
+  if (!header) return null;
+  const seconds = Number(header);
+  return Number.isFinite(seconds) ? seconds : null;
+}
+
+/**
+ * POST an address to `/api/check` and normalize the response into a
+ * `CheckOutcome`. Never throws — all failure modes (timeout, network error,
+ * non-2xx status, transient Horizon failure) are represented as outcomes.
+ */
+export async function checkAddressViaApi(
+  address: string,
+  options: { assetCode?: string; assetIssuer?: string } = {}
+): Promise<CheckOutcome> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), CHECK_TIMEOUT_MS);
+
+  try {
+    const response = await fetch("/api/check", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        address,
+        asset_code: options.assetCode,
+        asset_issuer: options.assetIssuer,
+      }),
+      signal: controller.signal,
+    });
+
+    if (response.status === 429) {
+      const body = (await response.json().catch(() => ({}))) as {
+        errors?: string[];
+      };
+      return {
+        kind: "rate_limited",
+        retryAfterSeconds: parseRetryAfter(response),
+        errors: body.errors ?? ["Rate limit exceeded. Please try again later."],
+      };
+    }
+
+    if (!response.ok) {
+      const body = (await response.json().catch(() => ({}))) as {
+        errors?: string[];
+      };
+      return {
+        kind: "error",
+        status: response.status,
+        errors: body.errors ?? ["Failed to check address"],
+      };
+    }
+
+    const result = (await response.json()) as HorizonCheckResult;
+
+    if (isTransientHorizonError(result.errors)) {
+      return { kind: "circuit_open", errors: result.errors };
+    }
+
+    return { kind: "ok", result };
+  } catch (error) {
+    if (error instanceof DOMException && error.name === "AbortError") {
+      return { kind: "timeout" };
+    }
+    // A same-shaped abort can also surface as a plain Error in some
+    // environments (e.g. jsdom/node-fetch polyfills) rather than a
+    // DOMException — treat any "aborted"-named error the same way.
+    if (
+      error instanceof Error &&
+      (error.name === "AbortError" || /aborted/i.test(error.message))
+    ) {
+      return { kind: "timeout" };
+    }
+    return { kind: "network_error" };
+  } finally {
+    clearTimeout(timer);
+  }
+}


### PR DESCRIPTION
Closes #136

## Summary
Replaces `AddressInput`'s single boolean `checking` flag with a status enum (`idle`, `checking`, `rate_limited`, `circuit_open`, `timeout`, `error`, `result`) so users get distinct, accessible messaging instead of an indefinite spinner when `/api/check` hits a rate limit, an open circuit breaker, or a hung request.

New `src/lib/check-api-client.ts` wraps the `POST /api/check` call and classifies the outcome:
- HTTP `429` (+ `Retry-After` header) → `rate_limited`
- HTTP `200` with an `errors` string matching the existing `"...temporarily unavailable..."` / `"Horizon error: ..."` convention already emitted by `src/lib/horizon.ts` → `circuit_open`
- An `AbortController`-based ~10s client-side timeout (didn't exist before) → `timeout`
- Anything else non-2xx → `error`

**No backend, retry-policy, or rate-limit changes** — this only surfaces signals the API already emits; `src/lib/circuit-breaker.ts`, `src/lib/rate-limit.ts`, and `src/app/api/check/route.ts` are untouched. The existing 500ms debounce is untouched too — this doesn't call `/api/check` any more often than before. A `requestIdRef` guards against a debounce/network race applying a stale response after a newer check has started.

Extended `src/components/AddressInput.test.tsx` with cases for 429/Retry-After, a transient circuit-open error string, an aborted/timed-out fetch, and the existing success/validation paths. New `src/lib/check-api-client.test.ts` covers the client helper directly.

## Also included
A one-line prerequisite fix for a pre-existing, unrelated syntax error in `WalletInstallStepper.tsx` (unescaped quotes) that breaks typecheck/build repo-wide — filed standalone in #230 as well, since it predates this branch and blocks every PR's CI.

## PR checklist (from the issue)
- [x] States
- [x] Tests

## Test plan
- [ ] `npm test`