### PR TITLE
Add contributor-facing address history timeline (#137)

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ All docs are cross-linked from this README:
 | `/api/auth/[...nextauth]` | GET/POST | NextAuth.js handlers |
 | `/api/check` | POST | Horizon validation `{ address, asset_code?, asset_issuer? }` | 10 req/min |
 | `/api/register` | GET/POST | Read/save contributor registration (authenticated) | — |
+| `/api/address-history` | GET | Contributor's own `AddressHistoryRecord` timeline, newest first (self only; maintainers may pass `?userId=` for another user) |
 | `/api/contributors` | GET/POST | List contributors / batch re-check (maintainer only). Response includes `registryMode` (`REGISTRY_MODE` env var) | — |
 | `/api/contributors/paginated` | GET | Cursor-paginated contributor list for infinite scroll (maintainer only). Also includes `registryMode` | — |
 | `/api/contributors/[id]` | POST | Re-check a **single** contributor via Horizon (maintainer only) |

--- a/docs/CSRF.md
+++ b/docs/CSRF.md
@@ -28,6 +28,7 @@ Because the application uses **cookie-based session authentication** (NextAuth J
 | `/api/stats` | GET | No (read-only, safe method) |
 | `/api/contributors` | GET | No (read-only, auth already enforced) |
 | `/api/register` | GET | No (read-only, auth already enforced) |
+| `/api/address-history` | GET | No (read-only, auth already enforced) |
 
 ---
 

--- a/src/app/api/address-history/route.ts
+++ b/src/app/api/address-history/route.ts
@@ -1,0 +1,34 @@
+import { getServerSession } from "next-auth";
+import { NextRequest, NextResponse } from "next/server";
+
+import { authOptions } from "@/lib/auth";
+import { getAddressHistory } from "@/lib/address-history";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/address-history — a contributor's own AddressHistoryRecord timeline.
+ *
+ * Self-only by default: the session user's own history is always returned.
+ * Maintainers may pass `?userId=<id>` to look up another user's history (for
+ * future maintainer tooling); non-maintainers passing that param are silently
+ * ignored and always get their own history back — never another user's
+ * (IDOR prevention).
+ */
+export async function GET(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const requestedUserId = request.nextUrl.searchParams.get("userId");
+  const targetUserId =
+    session.user.isMaintainer && requestedUserId
+      ? requestedUserId
+      : session.user.id;
+
+  const history = await getAddressHistory(targetUserId);
+
+  return NextResponse.json({ history });
+}

--- a/src/app/register/RegisterClient.tsx
+++ b/src/app/register/RegisterClient.tsx
@@ -6,6 +6,7 @@ import { useSearchParams } from "next/navigation";
 import { useState } from "react";
 import { CheckCircle2, Loader2 } from "lucide-react";
 
+import { AddressHistoryPanel } from "@/components/AddressHistoryPanel";
 import { AddressInput } from "@/components/AddressInput";
 import { AddressQr } from "@/components/AddressQr";
 import { FreighterProofCard } from "@/components/FreighterProofCard";
@@ -203,6 +204,10 @@ export function RegisterClient() {
           <FreighterProofCard proof={proof} addressReady={Boolean(proofAddress)} />
           <TrustlineGuidancePanel />
         </div>
+      </div>
+
+      <div className="mt-8">
+        <AddressHistoryPanel />
       </div>
 
       <div className="mt-12 border-t pt-8">

--- a/src/components/AddressHistoryPanel.test.tsx
+++ b/src/components/AddressHistoryPanel.test.tsx
@@ -1,0 +1,97 @@
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { AddressHistoryPanel } from "@/components/AddressHistoryPanel";
+
+function renderWithClient(ui: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>
+  );
+}
+
+function mockFetchOnce(body: unknown, ok = true) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok,
+      json: async () => body,
+    })
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("AddressHistoryPanel", () => {
+  it("shows a loading state before the fetch resolves", () => {
+    let resolveFetch: (value: unknown) => void = () => {};
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockReturnValue(
+        new Promise((resolve) => {
+          resolveFetch = resolve;
+        })
+      )
+    );
+
+    renderWithClient(<AddressHistoryPanel />);
+
+    expect(screen.getByTestId("address-history-loading")).toBeInTheDocument();
+    expect(screen.queryByTestId("address-history-empty")).not.toBeInTheDocument();
+
+    // Avoid an unhandled promise dangling after the test ends.
+    resolveFetch({ ok: true, json: async () => ({ history: [] }) });
+  });
+
+  it("shows an explicit empty state when there is no history", async () => {
+    mockFetchOnce({ history: [] });
+
+    renderWithClient(<AddressHistoryPanel />);
+
+    const emptyState = await screen.findByTestId("address-history-empty");
+    expect(emptyState).toHaveTextContent(/No address history yet/i);
+    expect(screen.queryByTestId("address-history-list")).not.toBeInTheDocument();
+  });
+
+  it("renders history entries newest-first as returned by the API", async () => {
+    mockFetchOnce({
+      history: [
+        {
+          stellarAddress: "GBSX" + "X".repeat(52),
+          changeType: "updated",
+          recordedAt: "2026-08-01T00:00:00.000Z",
+        },
+        {
+          stellarAddress: "GAAA" + "A".repeat(52),
+          changeType: "initial",
+          recordedAt: "2026-07-01T00:00:00.000Z",
+        },
+      ],
+    });
+
+    renderWithClient(<AddressHistoryPanel />);
+
+    const entries = await screen.findAllByTestId("address-history-entry");
+    expect(entries).toHaveLength(2);
+    expect(entries[0]).toHaveTextContent(/Address updated/i);
+    expect(entries[1]).toHaveTextContent(/Initial registration/i);
+  });
+
+  it("shows an error state when the fetch fails", async () => {
+    mockFetchOnce({ error: "boom" }, false);
+
+    renderWithClient(<AddressHistoryPanel />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("address-history-error")).toBeInTheDocument()
+    );
+    expect(screen.queryByTestId("address-history-empty")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/AddressHistoryPanel.tsx
+++ b/src/components/AddressHistoryPanel.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { Clock3, History, Loader2 } from "lucide-react";
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { cn, formatRelativeTime, shortenAddress } from "@/lib/utils";
+
+interface AddressHistoryEntry {
+  stellarAddress: string;
+  changeType: string;
+  recordedAt: string;
+}
+
+interface AddressHistoryResponse {
+  history: AddressHistoryEntry[];
+}
+
+const CHANGE_TYPE_LABEL: Record<string, string> = {
+  initial: "Initial registration",
+  updated: "Address updated",
+};
+
+interface AddressHistoryPanelProps {
+  className?: string;
+}
+
+export function AddressHistoryPanel({ className }: AddressHistoryPanelProps) {
+  const historyQuery = useQuery({
+    queryKey: ["address-history"],
+    queryFn: async () => {
+      const response = await fetch("/api/address-history");
+      if (!response.ok) throw new Error("Failed to load address history");
+      return (await response.json()) as AddressHistoryResponse;
+    },
+  });
+
+  const entries = historyQuery.data?.history ?? [];
+
+  return (
+    <Card className={cn("border-stellar-purple/20", className)} data-testid="address-history-panel">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-lg">
+          <History className="h-5 w-5 text-stellar-purple" />
+          Address history
+        </CardTitle>
+        <CardDescription>
+          A timeline of every Stellar address you have registered, newest
+          first.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3 text-sm">
+        {historyQuery.isLoading && (
+          <div
+            className="flex items-center justify-center py-10 text-muted-foreground"
+            role="status"
+            data-testid="address-history-loading"
+          >
+            <Loader2 className="mr-2 h-5 w-5 animate-spin" aria-hidden="true" />
+            Loading address history...
+          </div>
+        )}
+
+        {historyQuery.isError && (
+          <p
+            className="rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-destructive"
+            role="alert"
+            data-testid="address-history-error"
+          >
+            Could not load your address history. Try refreshing the page.
+          </p>
+        )}
+
+        {!historyQuery.isLoading && !historyQuery.isError && entries.length === 0 && (
+          <div
+            role="status"
+            aria-live="polite"
+            data-testid="address-history-empty"
+            className="rounded-xl border border-dashed bg-muted/20 px-6 py-10 text-center"
+          >
+            <Clock3
+              className="mx-auto h-8 w-8 text-muted-foreground"
+              aria-hidden="true"
+            />
+            <h3 className="mt-3 text-base font-semibold">No address history yet</h3>
+            <p className="mx-auto mt-2 max-w-sm text-sm text-muted-foreground">
+              Once you register a Stellar address, changes will show up here so
+              you can track what was on file and when.
+            </p>
+          </div>
+        )}
+
+        {!historyQuery.isLoading && !historyQuery.isError && entries.length > 0 && (
+          <ul className="space-y-3" data-testid="address-history-list">
+            {entries.map((entry, index) => (
+              <li
+                key={`${entry.recordedAt}-${index}`}
+                className="rounded-lg border bg-card/50 px-3 py-2"
+                data-testid="address-history-entry"
+              >
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <span className="font-medium">
+                    {CHANGE_TYPE_LABEL[entry.changeType] ?? entry.changeType}
+                  </span>
+                  <span className="text-xs text-muted-foreground">
+                    {formatRelativeTime(entry.recordedAt)}
+                  </span>
+                </div>
+                <p
+                  className="mt-1 font-mono text-xs text-muted-foreground break-all"
+                  title={entry.stellarAddress}
+                >
+                  {shortenAddress(entry.stellarAddress)}
+                </p>
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/WalletInstallStepper.tsx
+++ b/src/components/WalletInstallStepper.tsx
@@ -163,7 +163,7 @@ const WALLETS: WalletConfig[] = [
       {
         label: "Create or import a wallet",
         description:
-          "Open LOBSTR and tap "Create account" or "Import with secret key / recovery phrase". Back up your recovery phrase before continuing.",
+          'Open LOBSTR and tap "Create account" or "Import with secret key / recovery phrase". Back up your recovery phrase before continuing.',
       },
       {
         label: "Fund with XLM",
@@ -241,7 +241,7 @@ const WALLETS: WalletConfig[] = [
       {
         label: "Create or import a wallet",
         description:
-          "Open xBull and choose "Create a new wallet" or "Import wallet". Safely record your passphrase before moving on.",
+          'Open xBull and choose "Create a new wallet" or "Import wallet". Safely record your passphrase before moving on.',
       },
       {
         label: "Fund with XLM",

--- a/tests/api/address-history.test.ts
+++ b/tests/api/address-history.test.ts
@@ -1,0 +1,110 @@
+/**
+ * API tests — GET /api/address-history (#137)
+ *
+ * Self-only access to a contributor's own AddressHistoryRecord timeline.
+ * Maintainers may pass ?userId= to look up another user's history; the
+ * critical case is that non-maintainers passing that param NEVER leak
+ * another user's history (IDOR).
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { GET } from "@/app/api/address-history/route";
+
+vi.mock("next-auth", () => ({ getServerSession: vi.fn() }));
+vi.mock("@/lib/address-history", () => ({ getAddressHistory: vi.fn() }));
+
+import { getServerSession } from "next-auth";
+import { getAddressHistory } from "@/lib/address-history";
+
+function getRequest(query = "") {
+  return new NextRequest(`http://localhost:3000/api/address-history${query}`);
+}
+
+function mockSession(opts: { id?: string; isMaintainer?: boolean } = {}) {
+  vi.mocked(getServerSession).mockResolvedValue({
+    user: { id: opts.id ?? "user-1", isMaintainer: opts.isMaintainer ?? false },
+  } as never);
+}
+
+const SAMPLE_HISTORY = [
+  {
+    stellarAddress: "GBSX" + "X".repeat(52),
+    changeType: "updated",
+    recordedAt: new Date("2026-08-01T00:00:00.000Z"),
+  },
+  {
+    stellarAddress: "GAAA" + "A".repeat(52),
+    changeType: "initial",
+    recordedAt: new Date("2026-07-01T00:00:00.000Z"),
+  },
+];
+
+afterEach(() => vi.clearAllMocks());
+
+describe("GET /api/address-history — authentication", () => {
+  it("returns 401 when unauthenticated", async () => {
+    vi.mocked(getServerSession).mockResolvedValue(null);
+    const res = await GET(getRequest());
+    expect(res.status).toBe(401);
+    expect(getAddressHistory).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /api/address-history — self access", () => {
+  it("a signed-in contributor gets their own history back", async () => {
+    mockSession({ id: "user-1", isMaintainer: false });
+    vi.mocked(getAddressHistory).mockResolvedValue(SAMPLE_HISTORY as never);
+
+    const res = await GET(getRequest());
+    expect(res.status).toBe(200);
+    expect(getAddressHistory).toHaveBeenCalledWith("user-1");
+    const json = await res.json();
+    expect(json.history).toHaveLength(2);
+  });
+
+  it("returns an empty array when the user has no history yet", async () => {
+    mockSession({ id: "user-1", isMaintainer: false });
+    vi.mocked(getAddressHistory).mockResolvedValue([]);
+
+    const res = await GET(getRequest());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.history).toEqual([]);
+  });
+});
+
+describe("GET /api/address-history — maintainer lookup", () => {
+  it("a maintainer passing ?userId= gets that other user's history", async () => {
+    mockSession({ id: "maintainer-1", isMaintainer: true });
+    vi.mocked(getAddressHistory).mockResolvedValue(SAMPLE_HISTORY as never);
+
+    const res = await GET(getRequest("?userId=other-user"));
+    expect(res.status).toBe(200);
+    expect(getAddressHistory).toHaveBeenCalledWith("other-user");
+  });
+
+  it("a maintainer with no ?userId= still gets their own history", async () => {
+    mockSession({ id: "maintainer-1", isMaintainer: true });
+    vi.mocked(getAddressHistory).mockResolvedValue([]);
+
+    const res = await GET(getRequest());
+    expect(res.status).toBe(200);
+    expect(getAddressHistory).toHaveBeenCalledWith("maintainer-1");
+  });
+});
+
+describe("GET /api/address-history — IDOR prevention", () => {
+  it("a non-maintainer passing ?userId=<other-user-id> only gets their OWN history back", async () => {
+    mockSession({ id: "user-1", isMaintainer: false });
+    vi.mocked(getAddressHistory).mockResolvedValue(SAMPLE_HISTORY as never);
+
+    const res = await GET(getRequest("?userId=attacker-target-user"));
+
+    expect(res.status).toBe(200);
+    // Never called with the attacker-supplied userId.
+    expect(getAddressHistory).not.toHaveBeenCalledWith("attacker-target-user");
+    // Always called with the session user's own id.
+    expect(getAddressHistory).toHaveBeenCalledWith("user-1");
+    expect(getAddressHistory).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Closes #137

## Summary
New `GET /api/address-history` returns the signed-in user's own `AddressHistoryRecord` timeline via the already-scoped `getAddressHistory(userId)` helper in `src/lib/address-history.ts` (no new Prisma query logic, no migration — that model already has `@@index([userId])`/`@@index([recordedAt])`).

**Authorization: self-only unless maintainer.** A maintainer may pass `?userId=<id>` to look up another user's history (for future maintainer tooling); a non-maintainer passing that param is silently ignored and always gets back their own history only. This is covered by an explicit IDOR test in `tests/api/address-history.test.ts` that asserts the attacker-supplied `userId` is never forwarded to `getAddressHistory`.

GET-only, so no CSRF check is required (documented in `docs/CSRF.md` alongside the other exempt read-only routes).

New `AddressHistoryPanel` component (loading/error/empty/populated states, newest-first, `data-testid`s throughout) is wired into the register page as a new card section — self-view only, no maintainer UI consumes the `?userId=` path yet. `README.md`'s API routes table documents the new endpoint.

## Also included
A one-line prerequisite fix for a pre-existing, unrelated syntax error in `WalletInstallStepper.tsx` (unescaped quotes) that breaks typecheck/build repo-wide — filed standalone in #230 as well, since it predates this branch and blocks every PR's CI.

## PR checklist (from the issue)
- [x] API + UI
- [x] IDOR tests

## Test plan
- [ ] `npm test`