### PR TITLE
Add axe-core accessibility gate for /register and /dashboard (#142)

### DIFF
--- a/docs/E2E_TESTING.md
+++ b/docs/E2E_TESTING.md
@@ -16,6 +16,37 @@ npx playwright show-report              # last run
 | `tests/e2e/register.spec.ts` | Contributor registration: sign in, paste an address, read the readiness result, save, copy the Freighter proof. |
 | `tests/e2e/maintainer.spec.ts` | Maintainer dashboard: access control, contributor table, re-check, metrics, settings. |
 
+## Accessibility gate (axe-core)
+
+Issue #142. Each spec file has one test that signs in, loads its page to a
+fully-settled state (mocked APIs resolved, key content visible), and runs
+[`@axe-core/playwright`](https://www.npmjs.com/package/@axe-core/playwright)
+against it:
+
+- `register.spec.ts` → "the register page has no axe violations beyond the
+  baseline" — scans `/register` as a signed-in contributor.
+- `maintainer.spec.ts` → "the dashboard page has no axe violations beyond the
+  baseline" — scans `/dashboard` as a signed-in maintainer.
+
+Both scans run with `withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])`
+(axe-core's own best-practice-only rules, like landmark/region checks, are
+left out — noisy and not what WCAG conformance requires) and are gated by the
+existing `test:e2e` script, so they run in CI on every push and PR with no
+separate workflow step.
+
+**Baseline allowlist.** `tests/e2e/axe-baseline.ts` exports
+`AXE_BASELINE_RULE_IDS`, a short, dated, commented list of axe rule ids
+excluded from both gates via `filterBaselineViolations()`. Today it holds only
+`color-contrast`, because contrast is already covered by the from-scratch WCAG
+luminance calculator in `src/lib/dark-mode-contrast-audit.test.ts` — running
+axe's own contrast heuristic on top would duplicate that poorly (it flags
+transitioning, off-screen, and gradient-background text that unit tests
+already reason about correctly). Anything else added to this list should carry
+the same kind of comment: which rule, why it can't be fixed in this PR, and
+when to revisit. Keep it short — the point of the gate is to catch real
+regressions, not to grow a bigger exemption list every time a test is
+inconvenient.
+
 ## Signing in without GitHub
 
 Two things have to believe the user is signed in, and they are checked in

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "zod": "^3.22.4"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.13.0",
         "@playwright/test": "^1.45.3",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
@@ -160,6 +161,19 @@
       "license": "MIT",
       "peerDependencies": {
         "preact": ">=10"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.13.0.tgz",
+      "integrity": "sha512-6YLx+kxXu5GJceG4ozFg+33a2EMTdjYwWGloJ3sb9Kta5pp+ZNS53uxGVog5JetIY8s++P5UrtX+cri+u0VAVg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.13.0"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3712,9 +3726,9 @@
       }
     },
     "node_modules/axe-core": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
-      "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.13.0.tgz",
+      "integrity": "sha512-UzGt8zg7Ny8djbYMhxl2zuEevVa7r2gJjYY5Lwr1xM7+XU2nd6CkIWFTVcCIbAP63vSz71NaVyyuSk9lHKcy0A==",
       "dev": true,
       "license": "MPL-2.0",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.13.0",
     "@playwright/test": "^1.45.3",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",

--- a/src/components/WalletInstallStepper.tsx
+++ b/src/components/WalletInstallStepper.tsx
@@ -163,7 +163,7 @@ const WALLETS: WalletConfig[] = [
       {
         label: "Create or import a wallet",
         description:
-          "Open LOBSTR and tap "Create account" or "Import with secret key / recovery phrase". Back up your recovery phrase before continuing.",
+          'Open LOBSTR and tap "Create account" or "Import with secret key / recovery phrase". Back up your recovery phrase before continuing.',
       },
       {
         label: "Fund with XLM",
@@ -241,7 +241,7 @@ const WALLETS: WalletConfig[] = [
       {
         label: "Create or import a wallet",
         description:
-          "Open xBull and choose "Create a new wallet" or "Import wallet". Safely record your passphrase before moving on.",
+          'Open xBull and choose "Create a new wallet" or "Import wallet". Safely record your passphrase before moving on.',
       },
       {
         label: "Fund with XLM",

--- a/tests/e2e/axe-baseline.ts
+++ b/tests/e2e/axe-baseline.ts
@@ -1,0 +1,35 @@
+/**
+ * Time-boxed axe-core baseline for issue #142.
+ *
+ * Rule ids listed here are excluded from the `/register` and `/dashboard`
+ * axe gates in `tests/e2e/register.spec.ts` and `tests/e2e/maintainer.spec.ts`.
+ * This list should stay short — it is a temporary allowance, not a permanent
+ * suppression. Re-audit and shrink it; do not add a rule here just because a
+ * test is inconvenient to fix right now.
+ *
+ * - "color-contrast": already covered by the from-scratch WCAG luminance
+ *   calculator in `src/lib/dark-mode-contrast-audit.test.ts` (25 assertions
+ *   across light/dark and every badge/status color combination). axe-core's
+ *   own contrast heuristic duplicates that coverage poorly in a live browser
+ *   — it flags text inside elements that are transitioning, off-screen, or
+ *   rendered against a gradient background it cannot sample correctly — so
+ *   it is excluded here rather than fought from scratch. See issue #142's
+ *   "Watch for: color contrast already tested in unit — don't duplicate
+ *   poorly" guidance.
+ *
+ * Added 2026-08-28.
+ */
+export const AXE_BASELINE_RULE_IDS: readonly string[] = ["color-contrast"];
+
+interface AxeViolationLike {
+  id: string;
+}
+
+/** Drop baseline rule ids from a set of axe-core violations. */
+export function filterBaselineViolations<T extends AxeViolationLike>(
+  violations: readonly T[]
+): T[] {
+  return violations.filter(
+    (violation) => !AXE_BASELINE_RULE_IDS.includes(violation.id)
+  );
+}

--- a/tests/e2e/maintainer.spec.ts
+++ b/tests/e2e/maintainer.spec.ts
@@ -1,4 +1,7 @@
+import AxeBuilder from "@axe-core/playwright";
 import { test, expect } from "@playwright/test";
+
+import { filterBaselineViolations } from "./axe-baseline";
 import {
   interceptApi,
   mockContributorSession,
@@ -107,6 +110,34 @@ test.describe("Maintainer dashboard — access control", () => {
     await setupDashboard(page);
     await page.goto("/dashboard");
     await expect(page.getByRole("heading", { name: /maintainer dashboard/i })).toBeVisible();
+  });
+
+  // Issue #142 — axe-core accessibility gate.
+  //
+  // Runs on a fully signed-in maintainer /dashboard with every panel's data
+  // mocked (contributors, network config, Soroban events, stats): no real
+  // GitHub OAuth, Horizon, or database. `color-contrast` is excluded — it is
+  // already covered by the from-scratch WCAG luminance calculator in
+  // `src/lib/dark-mode-contrast-audit.test.ts`; see `tests/e2e/axe-baseline.ts`
+  // for the full rationale and the (currently empty beyond that) baseline.
+  test("the dashboard page has no axe violations beyond the baseline", async ({
+    page,
+  }) => {
+    await setupDashboard(page);
+    await page.goto("/dashboard");
+    await expect(
+      page.getByRole("heading", { name: /maintainer dashboard/i })
+    ).toBeVisible();
+    // Wait for the contributor table's async fetch to settle before scanning,
+    // so the gate reflects the steady-state page a maintainer sees.
+    await expect(page.getByText("@alice")).toBeVisible();
+
+    const results = await new AxeBuilder({ page })
+      .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
+      .analyze();
+
+    const violations = filterBaselineViolations(results.violations);
+    expect(violations, JSON.stringify(violations, null, 2)).toEqual([]);
   });
 });
 

--- a/tests/e2e/register.spec.ts
+++ b/tests/e2e/register.spec.ts
@@ -16,8 +16,10 @@
  * of issue #151 and will keep moving.
  */
 
+import AxeBuilder from "@axe-core/playwright";
 import { test, expect, type Page } from "@playwright/test";
 
+import { filterBaselineViolations } from "./axe-baseline";
 import { interceptApi, signInAsContributor } from "./helpers";
 
 // ── Fixtures ──────────────────────────────────────────────────────────────
@@ -180,6 +182,34 @@ test.describe("Register page — access", () => {
     await expect(
       page.getByTestId("register-page").getByText("@contributor", { exact: true })
     ).toBeVisible();
+  });
+
+  // Issue #142 — axe-core accessibility gate.
+  //
+  // Runs on a fully signed-in, fully mocked /register: no real GitHub OAuth,
+  // no real Horizon/Freighter calls. `color-contrast` is excluded here — it is
+  // already covered by the from-scratch WCAG luminance calculator in
+  // `src/lib/dark-mode-contrast-audit.test.ts`; see `tests/e2e/axe-baseline.ts`
+  // for the full rationale and the (currently empty beyond that) baseline.
+  test("the register page has no axe violations beyond the baseline", async ({
+    page,
+    context,
+  }) => {
+    await signInAsContributor(context, page);
+    await mockRegisterApis(page);
+
+    await page.goto("/register");
+    await expect(page.getByTestId("register-page")).toBeVisible();
+    // Let the async panels (network config, wallet stepper) settle before
+    // scanning, so the gate reflects the steady-state page a contributor sees.
+    await expect(page.getByTestId("trustline-guidance")).toBeVisible();
+
+    const results = await new AxeBuilder({ page })
+      .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
+      .analyze();
+
+    const violations = filterBaselineViolations(results.violations);
+    expect(violations, JSON.stringify(violations, null, 2)).toEqual([]);
   });
 
   test("the maintainer-only redirect explains itself", async ({


### PR DESCRIPTION
Closes #142

## Summary
Adds `@axe-core/playwright` and one scan test in each of `tests/e2e/register.spec.ts` and `tests/e2e/maintainer.spec.ts`, run after signing in (mocked auth, no real GitHub OAuth/Horizon/DB) and letting the page settle to a steady state. Scoped to `wcag2a`/`wcag2aa`/`wcag21a`/`wcag21aa` tags via `AxeBuilder.withTags()`. Runs inside the existing `e2e` CI job — no `.github/workflows/ci.yml` changes needed.

New `tests/e2e/axe-baseline.ts` is a short, dated, commented allowlist — currently just `color-contrast`, excluded because contrast is already covered by the from-scratch WCAG luminance calculator in `src/lib/dark-mode-contrast-audit.test.ts` (25 assertions across light/dark and every badge/status color combination). Running axe's own live-DOM contrast heuristic on top would duplicate that poorly — it flags text inside elements that are transitioning, off-screen, or rendered against a gradient it can't sample correctly — per the issue's own "Watch for: color contrast already tested in unit — don't duplicate poorly" guidance.

`docs/E2E_TESTING.md` documents the gate and the baseline policy (keep it short, re-audit and shrink it, don't add a rule just because a test is inconvenient).

I read through every component rendered on `/register` and `/dashboard` before writing this — the codebase was already accessibility-conscious going in (proper `aria-live` regions, `aria-describedby`, focus traps, a real ARIA tablist pattern, `main`/`header` landmarks, `html lang="en"`).

## Also included
A prerequisite fix for a pre-existing, unrelated syntax error in `WalletInstallStepper.tsx` (unescaped quotes, two spots) that breaks typecheck/build repo-wide — it had to be fixed here since the axe gate can't scan a page that won't compile. Filed standalone in #230 as well.

## PR checklist (from the issue)
- [x] axe gate
- [x] Fixes (pre-existing WalletInstallStepper syntax error; the app itself was already largely accessible)
- [x] Baseline (`color-contrast` only, dated and documented — see `tests/e2e/axe-baseline.ts`)

## Test plan
- [ ] `npm run test:e2e -- register.spec.ts maintainer.spec.ts`