### PR TITLE
feat: DLQ UI, feature flags, maintenance mode, opt-in OTEL traces (#200–#203)

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -113,6 +113,62 @@ Update or create OAuth App:
 
 ---
 
+## Maintenance mode
+
+Use maintenance mode when deploying during a Wave, running a migration, or
+otherwise doing work that must not race with maintainer writes.
+
+### Turning it on / off
+
+Set the **`MAINTENANCE`** environment variable to a truthy value (`1`, `true`,
+`on`, `yes`, `enabled`) and redeploy (or, on Vercel, edit the env var and
+redeploy). Unset it (or set it to `0`) to turn maintenance mode off.
+
+`MAINTENANCE` is intentionally **env-only**. It is the one switch that must keep
+working when the database is down, so it is never gated behind a DB flag — a
+maintainer can always disable it from the platform's env settings. Operators
+running with `FEATURE_FLAGS_DB_ENABLED` additionally have the `maintenance_mode`
+feature flag (`FeatureFlag` row or `FEATURE_FLAG_MAINTENANCE_MODE` env), which
+composes with `MAINTENANCE` (either one being on turns it on).
+
+Optional: **`MAINTENANCE_MESSAGE`** overrides the banner / 503 body text.
+
+### What it does
+
+| Surface | Behaviour while `MAINTENANCE` is on |
+|---|---|
+| Every page | Amber banner at the top (`src/components/MaintenanceBanner.tsx`) |
+| `GET` / `HEAD` on any route | Unchanged — **reads stay up** |
+| `POST` / `PUT` / `PATCH` / `DELETE` under `/api/*` | `503` `{ "error": "maintenance_mode" }` with `Retry-After: 120`, from `src/middleware.ts` |
+| `GET /api/health` | Still `200` — probes and uptime checks are unaffected |
+| `/api/auth/*` | Exempt — sign-in keeps working |
+| `/api/check` | Exempt — a pure Horizon read (POST only to keep the address out of logs); the registration page keeps validating addresses |
+| `/api/webhooks/*` | Exempt — GitHub / trustbridge-action deliveries are **not** dropped; they land and are processed normally |
+
+### Caveats to handle separately
+
+- **Scheduled jobs (cron).** Cron requests are not routed through the Next.js
+  middleware, so `/api/contract-sync`, email nudges, etc. **continue to run**
+  during maintenance. If a deploy needs them paused, disable the cron trigger
+  at the platform (Vercel Cron / GitHub Actions schedule) or set `CRON_SECRET`
+  to a value the scheduler doesn't have for the duration.
+- **Webhook side effects.** Because webhooks are exempt, a delivery received
+  mid-deploy will still write to the database. That is deliberate (retries are
+  finite and data would be lost otherwise) — factor it into migration ordering.
+- **In-flight background queue jobs** already `processing` when the deploy
+  starts are not interrupted; only the *enqueue* endpoints are blocked.
+
+### Validate
+
+```bash
+npm test -- middleware
+```
+
+covers `src/lib/maintenance.ts` and the middleware gate
+(`tests/unit/middleware-maintenance.test.ts`).
+
+---
+
 ## CI recommendation
 
 Add GitHub Actions workflow:

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -287,6 +287,92 @@ Minimum time between `/api/contract-sync` runs; a trigger inside this window ret
 
 ---
 
+## Feature flags (issue #201)
+
+`src/lib/feature-flags.ts` resolves each flag in this order:
+
+1. **Env override** — `FEATURE_FLAG_<KEY>` (highest precedence)
+2. **Database row** — only when `FEATURE_FLAGS_DB_ENABLED` is truthy
+3. **Built-in default**
+
+Risky flags **fail closed**: if the DB source is enabled but unreadable, they
+resolve to `false` regardless of their default, so a database outage can never
+silently open a dangerous write path. See [FEATURE_FLAGS.md](./FEATURE_FLAGS.md)
+for the full table and per-flag defaults.
+
+Accepted truthy values: `1`, `true`, `on`, `yes`, `enabled` (case-insensitive).
+Anything else is treated as falsy / "not set".
+
+### `FEATURE_FLAGS_DB_ENABLED`
+
+Optional. When truthy, the `FeatureFlag` table is consulted as source 2. When
+unset, only env overrides + built-in defaults apply and **no** database query is
+made. Default: unset.
+
+### `FEATURE_FLAGS_CACHE_TTL_MS`
+
+In-process cache TTL for DB-sourced flags. Default `30000` (30s). A failed DB
+read is cached for at most 5s so an outage can't hammer the connection pool.
+`clearFeatureFlagCache()` drops the cache immediately after a write.
+
+### `FEATURE_FLAG_BATCH_RECHECK` · `FEATURE_FLAG_INVITE_GENERATION` · `FEATURE_FLAG_DLQ_RETRY` · `FEATURE_FLAG_MAINTENANCE_MODE` · `FEATURE_FLAG_OTEL_TRACES`
+
+Per-flag env overrides. Set to a falsy value to freeze the corresponding
+feature during a Wave; unset to fall back to the DB row / default.
+
+---
+
+## Maintenance mode (issue #202)
+
+### `MAINTENANCE`
+
+Truthy => the maintenance banner is shown on every page and **mutating** API
+requests (`POST`/`PUT`/`PATCH`/`DELETE`) return `503` with `Retry-After: 120`.
+Reads (`GET`/`HEAD`) keep working. `/api/auth/*`, `/api/webhooks/*` and
+`/api/health` are exempt.
+
+This is the recommended kill switch and is **env-only on purpose** — a broken
+database can never strand maintainers who need to turn it back off. The
+`maintenance_mode` feature flag is an additional DB-backed toggle for operators
+who run with `FEATURE_FLAGS_DB_ENABLED`.
+
+See [DEPLOYMENT.md](./DEPLOYMENT.md#maintenance-mode) for the deploy runbook and
+the cron / webhook caveats.
+
+### `MAINTENANCE_MESSAGE`
+
+Optional. Overrides the banner + 503 body text.
+
+---
+
+## OpenTelemetry tracing (issue #203)
+
+Tracing is **off by default**. When enabled, spans are emitted for the API
+route, the Prisma query and the Horizon call on a request. Span names are
+scrubbed of Stellar addresses / emails and span attributes are run through the
+Sentry redactor before they leave the process.
+
+If `@opentelemetry/api` + an OTEL SDK are installed, the standard `OTEL_*`
+collector variables are honoured by that SDK. Otherwise spans are emitted as
+structured `trace` logs (visible only with `DEBUG` set) so the test suite needs
+no collector.
+
+### `OTEL_TRACES_ENABLED`
+
+Truthy => tracing on. Also toggled by `FEATURE_FLAG_OTEL_TRACES`. Default: off.
+
+### `OTEL_SERVICE_NAME`
+
+Service name reported on spans. Default `trustbridge-dashboard`.
+
+### `OTEL_EXPORTER_OTLP_ENDPOINT`
+
+Optional OTLP collector URL, consumed by the OTEL SDK when present. On
+serverless, ensure the SDK is configured with a span processor that flushes on
+function suspend (the SDK's responsibility, not this app's).
+
+---
+
 ## Vercel configuration
 
 1. Project → **Settings** → **Environment Variables**
@@ -310,6 +396,7 @@ For preview deployments, set `NEXTAUTH_URL` to the preview URL or use Vercel's a
 
 - [Setup guide](./SETUP.md)
 - [Deployment](./DEPLOYMENT.md)
+- [Feature flags](./FEATURE_FLAGS.md)
 - [Architecture](./ARCHITECTURE.md)
 
 - // src/lib/notifications/webhook.ts

--- a/docs/FEATURE_FLAGS.md
+++ b/docs/FEATURE_FLAGS.md
@@ -1,0 +1,101 @@
+# Feature flags
+
+← Back to [README](../README.md) · See also [Environment variables](./ENVIRONMENT.md)
+
+`src/lib/feature-flags.ts` is a small flags helper with two sources (env and an
+optional database table) plus a built-in default per flag. It exists so
+shipping-freeze windows, new webhooks, i18n, and other risky changes can be
+gated without a deploy — and turned **off** fast during a Wave.
+
+Out of scope: LaunchDarkly / a hosted flag service. An in-app admin UI is
+optional; `setFeatureFlag()` and `getAllFeatureFlags()` are provided for one.
+
+---
+
+## Resolution order
+
+For every flag, the first source that produces a value wins:
+
+1. **Env override** — `FEATURE_FLAG_<KEY>` (e.g. `FEATURE_FLAG_BATCH_RECHECK=off`).
+   Accepted truthy values: `1`, `true`, `on`, `yes`, `enabled`; falsy: `0`,
+   `false`, `off`, `no`, `disabled` (case-insensitive). An unrecognised value is
+   ignored and resolution falls through.
+2. **Database row** — a `FeatureFlag` row, **only** when `FEATURE_FLAGS_DB_ENABLED`
+   is truthy. Reads are cached in-process for `FEATURE_FLAGS_CACHE_TTL_MS`
+   (default 30s); `clearFeatureFlagCache()` is called automatically after
+   `setFeatureFlag()`.
+3. **Built-in default** — the `default` in `FEATURE_FLAGS`.
+
+### Fail closed
+
+Flags marked `risky` gate a mutating or destructive path. If the DB source is
+**enabled but unreadable** (connection error, table missing, …) a risky flag
+resolves to `false` — never to its default. A DB outage therefore *closes*
+risky writes rather than leaving them open. Non-risky flags fall back to their
+default in the same situation. An env override always wins, even when the DB is
+down.
+
+---
+
+## The flags
+
+| Key | Default | Risky | Gates | Documented at |
+|---|---|---|---|---|
+| `batch_recheck` | `true` | ✅ | `POST /api/contributors` — full batch recheck (one Horizon call per contributor) | `src/app/api/contributors/route.ts` |
+| `invite_generation` | `true` | ✅ | `POST /api/invites/generate` — bulk invite code creation | `src/app/api/invites/generate/route.ts` |
+| `dlq_retry` | `true` | ✅ | `POST /api/contributors/queue/dlq/[jobId]/retry` — re-queue a failed job | `src/app/api/contributors/queue/dlq/[jobId]/retry/route.ts` |
+| `maintenance_mode` | `false` | ✅ | Composes with the `MAINTENANCE` env var (see [DEPLOYMENT.md](./DEPLOYMENT.md#maintenance-mode)) | `src/lib/maintenance.ts` |
+| `otel_traces` | `false` | — | Opt-in tracing; composes with `OTEL_TRACES_ENABLED` (see [ENVIRONMENT.md](./ENVIRONMENT.md#opentelemetry-tracing-issue-203)) | `src/lib/tracing.ts` |
+
+### Two existing risky features are now gated (issue #201)
+
+- **Batch recheck** (`batch_recheck`). Previously any maintainer `POST` to
+  `/api/contributors` fanned out a Horizon call per contributor with no kill
+  switch. Now it returns `403 { "error": "Batch recheck is currently disabled" }`
+  when the flag is off.
+- **Invite generation** (`invite_generation`). `/api/invites/generate` now
+  returns `403 { "error": "Invite generation is currently disabled" }` when the
+  flag is off, so invite issuance can be frozen during a Wave.
+
+---
+
+## Usage
+
+```ts
+import { isFeatureEnabled } from "@/lib/feature-flags";
+
+if (!(await isFeatureEnabled("batch_recheck"))) {
+  return NextResponse.json({ error: "Batch recheck is currently disabled" }, { status: 403 });
+}
+```
+
+Edge middleware (no DB, no `server-only`):
+
+```ts
+import { isFeatureEnabledFromEnv } from "@/lib/feature-flags";
+```
+
+Admin / debug view:
+
+```ts
+import { getAllFeatureFlags, setFeatureFlag } from "@/lib/feature-flags";
+
+const flags = await getAllFeatureFlags(); // [{ key, enabled, source, risky, description }]
+await setFeatureFlag("batch_recheck", false, session.user.id); // requires FEATURE_FLAGS_DB_ENABLED
+```
+
+---
+
+## Database source
+
+Enable with `FEATURE_FLAGS_DB_ENABLED=1` and apply the migration
+(`prisma/migrations/20260829120000_add_feature_flag_model`). Rows are keyed by
+the flag name:
+
+```sql
+INSERT INTO "FeatureFlag" ("key", "enabled", "updatedAt")
+VALUES ('batch_recheck', false, now())
+ON CONFLICT ("key") DO UPDATE SET "enabled" = excluded."enabled", "updatedAt" = now();
+```
+
+When `FEATURE_FLAGS_DB_ENABLED` is unset, the table is never queried.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -3,6 +3,8 @@ const nextConfig = {
   // Next 14: keep stellar-sdk out of the RSC bundler (native deps)
   experimental: {
     serverComponentsExternalPackages: ["stellar-sdk", "sodium-native"],
+    // Enables src/instrumentation.ts (opt-in OpenTelemetry tracing, issue #203).
+    instrumentationHook: true,
   },
   webpack: (config, { isServer }) => {
     config.externals.push("pino-pretty", "lokijs", "encoding");

--- a/prisma/migrations/20260829120000_add_feature_flag_model/migration.sql
+++ b/prisma/migrations/20260829120000_add_feature_flag_model/migration.sql
@@ -1,0 +1,11 @@
+-- CreateTable
+CREATE TABLE "FeatureFlag" (
+    "key" TEXT NOT NULL,
+    "enabled" BOOLEAN NOT NULL DEFAULT false,
+    "description" TEXT,
+    "updatedById" TEXT,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "FeatureFlag_pkey" PRIMARY KEY ("key")
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -142,6 +142,17 @@ model QueueJob {
   @@index([type, status])
 }
 
+/// Optional database source for the feature-flags module (see src/lib/feature-flags.ts).
+/// Only consulted when FEATURE_FLAGS_DB_ENABLED is truthy; env overrides always win.
+model FeatureFlag {
+  key         String   @id
+  enabled     Boolean  @default(false)
+  description String?
+  updatedById String?
+  updatedAt   DateTime @updatedAt
+  createdAt   DateTime @default(now())
+}
+
 model Account {
   id                String  @id @default(cuid())
   userId            String

--- a/src/app/api/check/route.ts
+++ b/src/app/api/check/route.ts
@@ -7,6 +7,7 @@ import { DEFAULT_ASSET } from "@/lib/constants";
 import { checkStellarAddress } from "@/lib/horizon";
 import { checkCache, buildCacheKey } from "@/lib/cache";
 import { captureException } from "@/lib/sentry";
+import { withSpan } from "@/lib/tracing";
 import type { CheckAddressPayload, HorizonCheckResult } from "@/types";
 
 export const runtime = "nodejs";
@@ -52,49 +53,11 @@ export async function POST(request: NextRequest) {
   }
 
   try {
-    const body = (await request.json()) as CheckAddressPayload;
-    const address = body.address?.trim();
-
-    if (!address) {
-      return jsonCheckError(["Address is required"], 400);
-    }
-
-    const assetCode = body.asset_code ?? DEFAULT_ASSET.code;
-    const assetIssuer = body.asset_issuer ?? DEFAULT_ASSET.issuer;
-    const bypass = isCacheBypass(request);
-    const cacheKey = buildCheckCacheKey(address, assetCode, assetIssuer);
-
-    // ── KV cache read ────────────────────────────────────────────────────────
-    if (!bypass) {
-      const cached = checkCache.get(cacheKey) as HorizonCheckResult | null;
-      if (cached) {
-        return jsonCheckResult(cached);
-      }
-    }
-
-    // ── Horizon call ─────────────────────────────────────────────────────────
-    // Pass useCache: false when the caller explicitly bypassed the route cache
-    // so that even the internal horizon.ts verificationCache is skipped and a
-    // truly fresh Horizon response is returned.
-    const result = await checkStellarAddress(address, assetCode, assetIssuer, {
-      useCache: !bypass,
-    });
-
-    // ── KV cache write (success-only) ────────────────────────────────────────
-    // Transient / circuit-breaker errors are never cached so a follow-up
-    // request can succeed once Horizon recovers.
-    const isTransient =
-      result.errors?.some(
-        (e) =>
-          e.includes("temporarily unavailable") ||
-          e.startsWith("Horizon error:")
-      ) ?? false;
-
-    if (!bypass && !isTransient) {
-      checkCache.set(cacheKey, result);
-    }
-
-    return jsonCheckResult(result);
+    return await withSpan(
+      "api.check",
+      () => handleCheck(request),
+      { attributes: { "http.method": "POST", "http.route": "/api/check" } },
+    );
   } catch (error) {
     // NOTE: the address is intentionally *not* passed as context. It is the
     // one field a caller controls and it is a G-address — `captureException`
@@ -102,4 +65,50 @@ export async function POST(request: NextRequest) {
     captureException(error, { route: "/api/check", method: "POST" });
     return jsonCheckError(["Failed to check address"], 500);
   }
+}
+
+async function handleCheck(request: NextRequest): Promise<NextResponse> {
+  const body = (await request.json()) as CheckAddressPayload;
+  const address = body.address?.trim();
+
+  if (!address) {
+    return jsonCheckError(["Address is required"], 400);
+  }
+
+  const assetCode = body.asset_code ?? DEFAULT_ASSET.code;
+  const assetIssuer = body.asset_issuer ?? DEFAULT_ASSET.issuer;
+  const bypass = isCacheBypass(request);
+  const cacheKey = buildCheckCacheKey(address, assetCode, assetIssuer);
+
+  // ── KV cache read ────────────────────────────────────────────────────────
+  if (!bypass) {
+    const cached = checkCache.get(cacheKey) as HorizonCheckResult | null;
+    if (cached) {
+      return jsonCheckResult(cached);
+    }
+  }
+
+  // ── Horizon call ─────────────────────────────────────────────────────────
+  // Pass useCache: false when the caller explicitly bypassed the route cache
+  // so that even the internal horizon.ts verificationCache is skipped and a
+  // truly fresh Horizon response is returned.
+  const result = await checkStellarAddress(address, assetCode, assetIssuer, {
+    useCache: !bypass,
+  });
+
+  // ── KV cache write (success-only) ────────────────────────────────────────
+  // Transient / circuit-breaker errors are never cached so a follow-up
+  // request can succeed once Horizon recovers.
+  const isTransient =
+    result.errors?.some(
+      (e) =>
+        e.includes("temporarily unavailable") ||
+        e.startsWith("Horizon error:")
+    ) ?? false;
+
+  if (!bypass && !isTransient) {
+    checkCache.set(cacheKey, result);
+  }
+
+  return jsonCheckResult(result);
 }

--- a/src/app/api/contributors/queue/dlq/[jobId]/retry/route.ts
+++ b/src/app/api/contributors/queue/dlq/[jobId]/retry/route.ts
@@ -1,0 +1,66 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import { requireMaintainerSession } from "@/lib/api-auth";
+import { recordAuditLog } from "@/lib/audit";
+import { assertSameOrigin } from "@/lib/csrf";
+import { isFeatureEnabled } from "@/lib/feature-flags";
+import { backgroundQueue } from "@/lib/queue-worker";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+interface RouteContext {
+  params: { jobId: string };
+}
+
+/**
+ * POST /api/contributors/queue/dlq/[jobId]/retry — re-queue a failed job
+ * (issue #200).
+ *
+ * Maintainer-only, CSRF-guarded, gated behind the `dlq_retry` feature flag,
+ * and audited. Only jobs currently in the `failed` state and visible to the
+ * caller can be retried.
+ */
+export async function POST(request: NextRequest, { params }: RouteContext) {
+  const csrf = assertSameOrigin(request);
+  if (csrf) return csrf;
+
+  const session = await requireMaintainerSession();
+  if (!session) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  if (!(await isFeatureEnabled("dlq_retry"))) {
+    return NextResponse.json(
+      { error: "Dead-letter retry is currently disabled" },
+      { status: 403 }
+    );
+  }
+
+  const jobId = params.jobId?.trim();
+  if (!jobId) {
+    return NextResponse.json({ error: "Job ID is required" }, { status: 400 });
+  }
+
+  const job = await backgroundQueue.retryJob(jobId, {
+    ownerId: session.user.id,
+  });
+  if (!job) {
+    return NextResponse.json(
+      { error: "Job not found or not retryable" },
+      { status: 404 }
+    );
+  }
+
+  await recordAuditLog({
+    action: "queue.job.retried",
+    actorId: session.user.id,
+    actorLogin: session.user.githubUsername ?? null,
+    targetId: job.id,
+    metadata: { type: job.type },
+  });
+
+  return NextResponse.json({
+    job: { id: job.id, type: job.type, status: job.status },
+  });
+}

--- a/src/app/api/contributors/queue/dlq/route.ts
+++ b/src/app/api/contributors/queue/dlq/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from "next/server";
+
+import { requireMaintainerSession } from "@/lib/api-auth";
+import { backgroundQueue } from "@/lib/queue-worker";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/contributors/queue/dlq — dead-letter queue (issue #200).
+ *
+ * Lists the most recent failed jobs with their (redacted, size-capped) error.
+ * Maintainer-only; scoped to the caller's own jobs plus ownerless jobs.
+ */
+export async function GET(request: Request) {
+  const session = await requireMaintainerSession();
+  if (!session) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const url = new URL(request.url);
+  const parsedLimit = Number.parseInt(url.searchParams.get("limit") ?? "50", 10);
+  const limit = Number.isFinite(parsedLimit) ? parsedLimit : 50;
+
+  const jobs = await backgroundQueue.getFailedJobs({
+    limit,
+    ownerId: session.user.id,
+  });
+
+  return NextResponse.json({
+    jobs: jobs.map((job) => ({
+      id: job.id,
+      type: job.type,
+      status: job.status,
+      error: job.error ?? null,
+      attempts:
+        typeof (job.data as Record<string, unknown>)?.__retries === "number"
+          ? ((job.data as Record<string, unknown>).__retries as number)
+          : 0,
+      createdAt: job.createdAt,
+      startedAt: job.startedAt ?? null,
+      completedAt: job.completedAt ?? null,
+    })),
+    count: jobs.length,
+  });
+}

--- a/src/app/api/contributors/route.ts
+++ b/src/app/api/contributors/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { refreshMaintainerSession, requireMaintainerSession } from "@/lib/api-auth";
 import { recordAuditLog } from "@/lib/audit";
 import { assertSameOrigin } from "@/lib/csrf";
+import { isFeatureEnabled } from "@/lib/feature-flags";
 import { getRegistryMode } from "@/lib/registry-mode";
 import { getContributors } from "@/lib/registrations";
 import { backgroundQueue } from "@/lib/background-queue";
@@ -74,6 +75,16 @@ export async function POST(request: NextRequest) {
   const session = await requireMaintainerSession();
   if (!session) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  // Gated behind the `batch_recheck` feature flag (issue #201). A full batch
+  // recheck fans out one Horizon call per contributor, so it is a risky write
+  // that fails closed when the flag source is unreachable.
+  if (!(await isFeatureEnabled("batch_recheck"))) {
+    return NextResponse.json(
+      { error: "Batch recheck is currently disabled" },
+      { status: 403 }
+    );
   }
 
   try {

--- a/src/app/api/invites/generate/route.ts
+++ b/src/app/api/invites/generate/route.ts
@@ -4,6 +4,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { authOptions } from "@/lib/auth";
 import { recordAuditLog } from "@/lib/audit";
 import { assertSameOrigin } from "@/lib/csrf";
+import { isFeatureEnabled } from "@/lib/feature-flags";
 import {
   createInvite,
   generateInviteCode,
@@ -32,6 +33,15 @@ export async function POST(request: NextRequest) {
 
   if (!session?.user?.id || !session.user.isMaintainer) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  // Gated behind the `invite_generation` feature flag (issue #201) so invite
+  // issuance can be frozen during a Wave. Risky write → fails closed.
+  if (!(await isFeatureEnabled("invite_generation"))) {
+    return NextResponse.json(
+      { error: "Invite generation is currently disabled" },
+      { status: 403 }
+    );
   }
 
   const body = (await request.json()) as GenerateBulkInvitesRequest;

--- a/src/app/dashboard/queue/page.tsx
+++ b/src/app/dashboard/queue/page.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { AlertTriangle, Loader2, RefreshCw, RotateCw } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { formatRelativeTime } from "@/lib/utils";
+
+interface FailedJob {
+  id: string;
+  type: string;
+  status: string;
+  error: string | null;
+  attempts: number;
+  createdAt: string;
+  startedAt: string | null;
+  completedAt: string | null;
+}
+
+interface DlqResponse {
+  jobs: FailedJob[];
+  count: number;
+}
+
+export default function DeadLetterQueuePage() {
+  const queryClient = useQueryClient();
+
+  const dlqQuery = useQuery({
+    queryKey: ["queue", "dlq"],
+    queryFn: async () => {
+      const response = await fetch("/api/contributors/queue/dlq");
+      if (!response.ok) throw new Error("Failed to load failed jobs");
+      return (await response.json()) as DlqResponse;
+    },
+  });
+
+  const retryMutation = useMutation({
+    mutationFn: async (jobId: string) => {
+      const response = await fetch(
+        `/api/contributors/queue/dlq/${jobId}/retry`,
+        { method: "POST" },
+      );
+      if (!response.ok) {
+        const body = (await response.json().catch(() => null)) as
+          | { error?: string }
+          | null;
+        throw new Error(body?.error ?? "Retry failed");
+      }
+      return (await response.json()) as { job: { id: string } };
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["queue", "dlq"] });
+    },
+  });
+
+  const jobs = dlqQuery.data?.jobs ?? [];
+
+  return (
+    <div className="mx-auto max-w-6xl px-4 py-10 sm:px-6">
+      <div className="mb-8 flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <h1 className="text-3xl font-bold">Dead-letter queue</h1>
+          <p className="mt-2 text-muted-foreground">
+            Recheck and email jobs that failed after all retries. Fix the
+            underlying cause, then re-queue.
+          </p>
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => dlqQuery.refetch()}
+          disabled={dlqQuery.isFetching}
+        >
+          {dlqQuery.isFetching ? (
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+          ) : (
+            <RefreshCw className="mr-2 h-4 w-4" />
+          )}
+          Refresh
+        </Button>
+      </div>
+
+      {retryMutation.isError ? (
+        <p className="mb-4 text-sm text-destructive" role="alert">
+          {(retryMutation.error as Error).message}
+        </p>
+      ) : null}
+
+      {dlqQuery.isLoading ? (
+        <div className="flex items-center justify-center py-16 text-muted-foreground">
+          <Loader2 className="mr-2 h-5 w-5 animate-spin" />
+          Loading failed jobs…
+        </div>
+      ) : dlqQuery.isError ? (
+        <p className="text-destructive">
+          Could not load the dead-letter queue. Try again.
+        </p>
+      ) : jobs.length === 0 ? (
+        <Card>
+          <CardContent className="flex flex-col items-center gap-2 py-16 text-center text-muted-foreground">
+            <AlertTriangle className="h-8 w-8 text-muted-foreground/60" />
+            <p className="font-medium text-foreground">No failed jobs</p>
+            <p className="text-sm">
+              Every recheck and email job has completed successfully.
+            </p>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="space-y-4">
+          {jobs.map((job) => (
+            <Card key={job.id}>
+              <CardHeader className="flex flex-row items-start justify-between gap-4 space-y-0">
+                <div className="min-w-0">
+                  <CardTitle className="font-mono text-sm">{job.type}</CardTitle>
+                  <CardDescription className="mt-1 space-x-2">
+                    <span className="font-mono">{job.id}</span>
+                    <span>·</span>
+                    <span>failed {formatRelativeTime(job.completedAt)}</span>
+                    {job.attempts > 0 ? (
+                      <>
+                        <span>·</span>
+                        <span>{job.attempts} previous retr{job.attempts === 1 ? "y" : "ies"}</span>
+                      </>
+                    ) : null}
+                  </CardDescription>
+                </div>
+                <Button
+                  size="sm"
+                  onClick={() => retryMutation.mutate(job.id)}
+                  disabled={
+                    retryMutation.isPending &&
+                    retryMutation.variables === job.id
+                  }
+                >
+                  {retryMutation.isPending &&
+                  retryMutation.variables === job.id ? (
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  ) : (
+                    <RotateCw className="mr-2 h-4 w-4" />
+                  )}
+                  Retry
+                </Button>
+              </CardHeader>
+              <CardContent>
+                <pre className="max-h-48 overflow-auto whitespace-pre-wrap break-words rounded-md bg-muted p-3 text-xs text-muted-foreground">
+                  {job.error ?? "(no error message recorded)"}
+                </pre>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,9 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 
+import { MaintenanceBanner } from "@/components/MaintenanceBanner";
 import { Providers } from "@/components/Providers";
+import { getMaintenanceMessage, isMaintenanceMode } from "@/lib/maintenance";
 
 import "./globals.css";
 
@@ -30,15 +32,23 @@ export const metadata: Metadata = {
   },
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const maintenance = await isMaintenanceMode();
+
   return (
     <html lang="en" suppressHydrationWarning>
       <body className={`${inter.variable} font-sans min-h-screen`}>
-        <Providers>{children}</Providers>
+        <Providers>
+          <MaintenanceBanner
+            enabled={maintenance}
+            message={getMaintenanceMessage()}
+          />
+          {children}
+        </Providers>
       </body>
     </html>
   );

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -150,6 +150,11 @@ export function Header() {
             </Link>
           )}
           {session?.user?.isMaintainer && (
+            <Link href="/dashboard/queue" className={navLinkClass}>
+              Failed jobs
+            </Link>
+          )}
+          {session?.user?.isMaintainer && (
             <Link href="/dashboard/settings" className={navLinkClass}>
               Settings
             </Link>
@@ -323,6 +328,15 @@ export function Header() {
                   onClick={closeMenu}
                 >
                   Dashboard
+                </Link>
+              )}
+              {session?.user?.isMaintainer && (
+                <Link
+                  href="/dashboard/queue"
+                  className={cn(navLinkClass, "rounded-md px-3 py-2")}
+                  onClick={closeMenu}
+                >
+                  Failed jobs
                 </Link>
               )}
               {session?.user?.isMaintainer && (

--- a/src/components/MaintenanceBanner.tsx
+++ b/src/components/MaintenanceBanner.tsx
@@ -1,0 +1,31 @@
+import { AlertTriangle } from "lucide-react";
+
+/**
+ * Site-wide maintenance banner (issue #202).
+ *
+ * Pure/sync component — the layout resolves whether maintenance mode is on
+ * (via the `MAINTENANCE` env var or the `maintenance_mode` feature flag) and
+ * passes the result in. While maintenance mode is on, reads keep working but
+ * mutating API requests get a 503 from the middleware.
+ */
+export function MaintenanceBanner({
+  enabled,
+  message,
+}: {
+  enabled: boolean;
+  message: string;
+}) {
+  if (!enabled) return null;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      data-testid="maintenance-banner"
+      className="flex items-center justify-center gap-2 border-b border-amber-300 bg-amber-100 px-4 py-2 text-center text-sm font-medium text-amber-900 dark:border-amber-700 dark:bg-amber-950 dark:text-amber-100"
+    >
+      <AlertTriangle className="h-4 w-4 shrink-0" aria-hidden="true" />
+      <span>{message}</span>
+    </div>
+  );
+}

--- a/src/components/WalletInstallStepper.tsx
+++ b/src/components/WalletInstallStepper.tsx
@@ -163,7 +163,7 @@ const WALLETS: WalletConfig[] = [
       {
         label: "Create or import a wallet",
         description:
-          "Open LOBSTR and tap "Create account" or "Import with secret key / recovery phrase". Back up your recovery phrase before continuing.",
+          'Open LOBSTR and tap "Create account" or "Import with secret key / recovery phrase". Back up your recovery phrase before continuing.',
       },
       {
         label: "Fund with XLM",
@@ -241,7 +241,7 @@ const WALLETS: WalletConfig[] = [
       {
         label: "Create or import a wallet",
         description:
-          "Open xBull and choose "Create a new wallet" or "Import wallet". Safely record your passphrase before moving on.",
+          'Open xBull and choose "Create a new wallet" or "Import wallet". Safely record your passphrase before moving on.',
       },
       {
         label: "Fund with XLM",
@@ -355,8 +355,6 @@ export function WalletInstallStepper({ className }: WalletInstallStepperProps) {
       setActiveIdx(WALLETS.length - 1);
     }
   }
-
-  const active = WALLETS[activeIdx];
 
   return (
     <div className={className}>

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,0 +1,31 @@
+/**
+ * Next.js instrumentation hook (issue #203).
+ *
+ * Runs once per server process. Tracing is OFF unless `OTEL_TRACES_ENABLED`
+ * (or the `otel_traces` flag) is set, so this is a no-op in the default
+ * configuration and in tests.
+ *
+ * When an OpenTelemetry SDK / `@opentelemetry/api` is present the standard
+ * `OTEL_*` collector env vars are honoured by that SDK; this hook only records
+ * that tracing is active. Serverless flushing is the SDK's responsibility —
+ * see docs/ENVIRONMENT.md.
+ */
+export async function register(): Promise<void> {
+  const { isTracingEnabled } = await import("@/lib/tracing");
+  if (!isTracingEnabled()) return;
+
+  if (process.env.NEXT_RUNTIME === "nodejs") {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        level: "info",
+        context: "instrumentation",
+        message: "tracing_enabled",
+        details: {
+          service: process.env.OTEL_SERVICE_NAME || "trustbridge-dashboard",
+          exporter: process.env.OTEL_EXPORTER_OTLP_ENDPOINT || "log-spans",
+        },
+      }),
+    );
+  }
+}

--- a/src/lib/audit-format.ts
+++ b/src/lib/audit-format.ts
@@ -7,6 +7,7 @@ export const AUDIT_ACTION_LABELS: Record<string, string> = {
   "registration.create": "Registered a Stellar address",
   "registration.update": "Updated a Stellar address",
   network_config_mismatch_detected: "Detected a Horizon/Soroban network mismatch",
+  "queue.job.retried": "Retried a failed job from the dead-letter queue",
 };
 
 export function describeAuditAction(action: string): string {

--- a/src/lib/background-queue.ts
+++ b/src/lib/background-queue.ts
@@ -1,6 +1,29 @@
 import "server-only";
 
+import { Prisma } from "@prisma/client";
+
 import { prisma } from "@/lib/prisma";
+import { redactString } from "@/lib/sentry";
+
+/**
+ * Upper bound on a stored job error string (issue #200). A stack trace or a
+ * dumped payload can be arbitrarily large; cap it so the dead-letter queue
+ * can't bloat the row or the DLQ API response.
+ */
+export const MAX_ERROR_LENGTH = 2000;
+
+/**
+ * Normalise an error before it is persisted on a failed job:
+ *  - run it through the Sentry redactor so a contributor address / token /
+ *    email in the message never lands in the DLQ
+ *  - cap the length
+ */
+export function sanitizeJobError(raw: string): string {
+  const redacted = redactString(raw);
+  return redacted.length > MAX_ERROR_LENGTH
+    ? `${redacted.slice(0, MAX_ERROR_LENGTH)}…[truncated]`
+    : redacted;
+}
 
 export type JobType = "recheck.batch" | "recheck.single";
 
@@ -78,10 +101,18 @@ class BackgroundQueue {
     return record.id;
   }
 
-  async getJob(id: string): Promise<Job | undefined> {
-    const record = await prisma.queueJob.findUnique({ where: { id } });
-    if (!record) return undefined;
-
+  private toJob(record: {
+    id: string;
+    type: string;
+    data: unknown;
+    status: string;
+    createdAt: Date;
+    startedAt: Date | null;
+    completedAt: Date | null;
+    error: string | null;
+    result: unknown;
+    ownerId: string | null;
+  }): Job {
     return {
       id: record.id,
       type: record.type as JobType,
@@ -94,6 +125,78 @@ class BackgroundQueue {
       result: (record.result as Record<string, unknown>) ?? undefined,
       ownerId: record.ownerId ?? undefined,
     };
+  }
+
+  async getJob(id: string): Promise<Job | undefined> {
+    const record = await prisma.queueJob.findUnique({ where: { id } });
+    if (!record) return undefined;
+    return this.toJob(record);
+  }
+
+  /**
+   * Dead-letter queue: the most recent failed jobs (issue #200).
+   * Scoped to the caller's own jobs plus ownerless jobs, mirroring the
+   * per-job endpoint's visibility rule.
+   */
+  async getFailedJobs(
+    options: { limit?: number; ownerId?: string } = {},
+  ): Promise<Job[]> {
+    const limit = Math.min(Math.max(1, Math.floor(options.limit ?? 50)), 200);
+    const records = await prisma.queueJob.findMany({
+      where: {
+        status: "failed",
+        ...(options.ownerId
+          ? { OR: [{ ownerId: options.ownerId }, { ownerId: null }] }
+          : {}),
+      },
+      orderBy: { completedAt: "desc" },
+      take: limit,
+    });
+    return records.map((record) => this.toJob(record));
+  }
+
+  /**
+   * Re-queue a failed job (issue #200). Returns the updated job, or null when
+   * the job does not exist, is not in the `failed` state, or belongs to a
+   * different owner. Retry count is tracked on `data.__retries` so the UI can
+   * show it and a future policy can cap it.
+   */
+  async retryJob(
+    jobId: string,
+    options: { ownerId?: string } = {},
+  ): Promise<Job | null> {
+    const record = await prisma.queueJob.findUnique({ where: { id: jobId } });
+    if (!record || record.status !== "failed") return null;
+    if (
+      options.ownerId &&
+      record.ownerId &&
+      record.ownerId !== options.ownerId
+    ) {
+      return null;
+    }
+
+    const prevData = (record.data as Record<string, unknown>) ?? {};
+    const retries =
+      typeof prevData.__retries === "number" ? prevData.__retries : 0;
+
+    const updated = await prisma.queueJob.update({
+      where: { id: jobId },
+      data: {
+        status: "pending",
+        error: null,
+        result: Prisma.DbNull,
+        startedAt: null,
+        completedAt: null,
+        data: { ...prevData, __retries: retries + 1 } as never,
+      },
+    });
+
+    if (!this.queue.includes(jobId)) this.queue.push(jobId);
+    if (!this.workerStarted && this.shouldAutoStartWorker()) {
+      void this.startWorker();
+    }
+
+    return this.toJob(updated);
   }
 
   async getMetrics(): Promise<QueueMetrics> {
@@ -214,7 +317,9 @@ class BackgroundQueue {
         },
       });
     } catch (error) {
-      const errorMsg = error instanceof Error ? error.message : String(error);
+      const errorMsg = sanitizeJobError(
+        error instanceof Error ? error.message : String(error),
+      );
       await prisma.queueJob.update({
         where: { id: jobId },
         data: {

--- a/src/lib/env-validation.ts
+++ b/src/lib/env-validation.ts
@@ -105,6 +105,37 @@ const envSchema = z.object({
     .pipe(z.number().int().positive())
     .optional()
     .default("86400000"), // 24 hours
+
+  // ── Feature flags (issue #201) ──────────────────────────────────────────────
+  // Optional DB source. When falsy, only env overrides + built-in defaults apply.
+  FEATURE_FLAGS_DB_ENABLED: z.string().optional(),
+  // In-process cache TTL for DB-sourced flags.
+  FEATURE_FLAGS_CACHE_TTL_MS: z
+    .string()
+    .transform((v) => parseInt(v, 10))
+    .pipe(z.number().int().nonnegative())
+    .optional()
+    .default("30000"),
+  // Per-flag env overrides (highest precedence). See src/lib/feature-flags.ts.
+  FEATURE_FLAG_BATCH_RECHECK: z.string().optional(),
+  FEATURE_FLAG_INVITE_GENERATION: z.string().optional(),
+  FEATURE_FLAG_DLQ_RETRY: z.string().optional(),
+  FEATURE_FLAG_MAINTENANCE_MODE: z.string().optional(),
+  FEATURE_FLAG_OTEL_TRACES: z.string().optional(),
+
+  // ── Maintenance mode (issue #202) ──────────────────────────────────────────
+  // Truthy => banner shown and mutating APIs return 503. Env-only kill switch.
+  MAINTENANCE: z.string().optional(),
+  MAINTENANCE_MESSAGE: z.string().optional(),
+
+  // ── OpenTelemetry tracing (issue #203) ────────────────────────────────────
+  // Default off. Truthy => spans emitted for route / prisma / horizon hops.
+  OTEL_TRACES_ENABLED: z.string().optional(),
+  OTEL_SERVICE_NAME: z.string().optional().default("trustbridge-dashboard"),
+  OTEL_EXPORTER_OTLP_ENDPOINT: z
+    .string()
+    .url("OTEL_EXPORTER_OTLP_ENDPOINT must be a valid URL")
+    .optional(),
 });
 
 export type Environment = z.infer<typeof envSchema>;

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -1,0 +1,234 @@
+import "server-only";
+
+import { prisma } from "@/lib/prisma";
+
+/**
+ * Feature flags for the TrustBridge Dashboard (issue #201).
+ *
+ * Resolution order for every flag:
+ *   1. Environment override  — `FEATURE_FLAG_<KEY>` (e.g. FEATURE_FLAG_BATCH_RECHECK)
+ *   2. Database row          — only when `FEATURE_FLAGS_DB_ENABLED` is truthy
+ *   3. Built-in default      — the `default` field below
+ *
+ * "Fail closed" for risky writes: when the DB source is enabled but unreadable
+ * (connection error, migration not applied, …) a `risky` flag resolves to
+ * `false` regardless of its default, so a database outage can never silently
+ * open a dangerous code path.
+ *
+ * DB reads are cached in-process for `FEATURE_FLAGS_CACHE_TTL_MS` (default 30s).
+ * Call {@link clearFeatureFlagCache} after writing a flag so the change is
+ * visible immediately in the current process.
+ */
+
+export type FeatureFlagKey =
+  | "batch_recheck"
+  | "invite_generation"
+  | "dlq_retry"
+  | "maintenance_mode"
+  | "otel_traces";
+
+interface FlagDefinition {
+  description: string;
+  /** Value used when there is no env override and no usable DB row. */
+  default: boolean;
+  /**
+   * Risky flags gate mutating / destructive behaviour. They fail closed: if
+   * the DB source is enabled but unreadable, the flag resolves to `false`.
+   */
+  risky: boolean;
+}
+
+export const FEATURE_FLAGS: Record<FeatureFlagKey, FlagDefinition> = {
+  batch_recheck: {
+    description:
+      "Allow maintainers to enqueue a full batch recheck of every contributor.",
+    default: true,
+    risky: true,
+  },
+  invite_generation: {
+    description: "Allow maintainers to generate invite codes.",
+    default: true,
+    risky: true,
+  },
+  dlq_retry: {
+    description:
+      "Allow maintainers to retry failed jobs from the dead-letter queue.",
+    default: true,
+    risky: true,
+  },
+  maintenance_mode: {
+    description:
+      "Serve the maintenance banner and 503 mutating APIs. The MAINTENANCE=1 env var does the same and is the recommended kill switch.",
+    default: false,
+    risky: true,
+  },
+  otel_traces: {
+    description:
+      "Emit OpenTelemetry-style spans for API routes, Prisma and Horizon calls. Also toggled by OTEL_TRACES_ENABLED.",
+    default: false,
+    risky: false,
+  },
+};
+
+export const FEATURE_FLAG_KEYS = Object.keys(FEATURE_FLAGS) as FeatureFlagKey[];
+
+const TRUTHY = new Set(["1", "true", "on", "yes", "enabled"]);
+const FALSY = new Set(["0", "false", "off", "no", "disabled"]);
+
+function parseBoolEnv(raw: string | undefined): boolean | undefined {
+  if (raw == null) return undefined;
+  const v = raw.trim().toLowerCase();
+  if (v === "") return undefined;
+  if (TRUTHY.has(v)) return true;
+  if (FALSY.has(v)) return false;
+  return undefined;
+}
+
+function envOverride(key: FeatureFlagKey): boolean | undefined {
+  return parseBoolEnv(process.env[`FEATURE_FLAG_${key.toUpperCase()}`]);
+}
+
+function dbSourceEnabled(): boolean {
+  return parseBoolEnv(process.env.FEATURE_FLAGS_DB_ENABLED) === true;
+}
+
+function cacheTtlMs(): number {
+  const n = Number.parseInt(process.env.FEATURE_FLAGS_CACHE_TTL_MS ?? "", 10);
+  return Number.isFinite(n) && n >= 0 ? n : 30_000;
+}
+
+interface DbCacheEntry {
+  /** null value => DB source enabled but the read failed (fail-closed path). */
+  flags: Map<string, boolean> | null;
+  expiresAt: number;
+}
+
+let dbCache: DbCacheEntry | null = null;
+
+/** Drop the cached DB snapshot so the next read hits the database again. */
+export function clearFeatureFlagCache(): void {
+  dbCache = null;
+}
+
+async function readDbFlags(): Promise<Map<string, boolean> | null> {
+  const now = Date.now();
+  if (dbCache && dbCache.expiresAt > now) return dbCache.flags;
+
+  try {
+    const rows = await prisma.featureFlag.findMany({
+      select: { key: true, enabled: true },
+    });
+    const map = new Map<string, boolean>();
+    for (const row of rows) map.set(row.key, row.enabled);
+    dbCache = { flags: map, expiresAt: now + cacheTtlMs() };
+    return map;
+  } catch (error) {
+    console.error("[feature-flags] database read failed; failing closed", error);
+    // Cache the failure briefly so a hard DB outage doesn't hammer the pool.
+    dbCache = { flags: null, expiresAt: now + Math.min(cacheTtlMs(), 5_000) };
+    return null;
+  }
+}
+
+export type FlagSource = "env" | "db" | "default" | "fail-closed";
+
+export interface ResolvedFlag {
+  key: FeatureFlagKey;
+  description: string;
+  enabled: boolean;
+  source: FlagSource;
+  risky: boolean;
+}
+
+function resolve(
+  key: FeatureFlagKey,
+  dbFlags: Map<string, boolean> | null,
+): ResolvedFlag {
+  const def = FEATURE_FLAGS[key];
+  const base = { key, description: def.description, risky: def.risky };
+
+  const override = envOverride(key);
+  if (override !== undefined) {
+    return { ...base, enabled: override, source: "env" };
+  }
+
+  if (dbSourceEnabled()) {
+    if (dbFlags === null) {
+      // Unreadable DB source: risky flags fail closed, others fall back to default.
+      return {
+        ...base,
+        enabled: def.risky ? false : def.default,
+        source: "fail-closed",
+      };
+    }
+    const dbVal = dbFlags.get(key);
+    if (dbVal !== undefined) {
+      return { ...base, enabled: dbVal, source: "db" };
+    }
+  }
+
+  return { ...base, enabled: def.default, source: "default" };
+}
+
+/**
+ * Resolve a single feature flag. Safe to call on every request — the DB read
+ * (when enabled) is cached in-process.
+ */
+export async function isFeatureEnabled(key: FeatureFlagKey): Promise<boolean> {
+  if (!(key in FEATURE_FLAGS)) return false;
+
+  // Fast path: an env override short-circuits before touching the database.
+  const override = envOverride(key);
+  if (override !== undefined) return override;
+
+  const dbFlags = dbSourceEnabled() ? await readDbFlags() : null;
+  return resolve(key, dbFlags).enabled;
+}
+
+/**
+ * Env-only resolution: env override, otherwise the built-in default. Never
+ * touches the database, so it is safe from the Edge middleware runtime.
+ */
+export function isFeatureEnabledFromEnv(key: FeatureFlagKey): boolean {
+  if (!(key in FEATURE_FLAGS)) return false;
+  const override = envOverride(key);
+  if (override !== undefined) return override;
+  return FEATURE_FLAGS[key].default;
+}
+
+/** Resolve every known flag, including its source — for docs / an admin view. */
+export async function getAllFeatureFlags(): Promise<ResolvedFlag[]> {
+  const dbFlags = dbSourceEnabled() ? await readDbFlags() : null;
+  return FEATURE_FLAG_KEYS.map((key) => resolve(key, dbFlags));
+}
+
+/**
+ * Upsert a flag into the database source and clear the cache.
+ * Throws when the DB source is disabled — callers should surface that to the
+ * admin UI rather than silently no-op.
+ */
+export async function setFeatureFlag(
+  key: FeatureFlagKey,
+  enabled: boolean,
+  updatedById?: string,
+): Promise<void> {
+  if (!(key in FEATURE_FLAGS)) {
+    throw new Error(`Unknown feature flag: ${key}`);
+  }
+  if (!dbSourceEnabled()) {
+    throw new Error(
+      "FEATURE_FLAGS_DB_ENABLED is not set; database flag writes are disabled.",
+    );
+  }
+  await prisma.featureFlag.upsert({
+    where: { key },
+    create: {
+      key,
+      enabled,
+      description: FEATURE_FLAGS[key].description,
+      updatedById: updatedById ?? null,
+    },
+    update: { enabled, updatedById: updatedById ?? null },
+  });
+  clearFeatureFlagCache();
+}

--- a/src/lib/horizon.ts
+++ b/src/lib/horizon.ts
@@ -12,6 +12,7 @@ import {
   isAccountNotFoundError,
 } from "@/lib/readiness";
 import { withRetry } from "@/lib/retry";
+import { withSpan } from "@/lib/tracing";
 import {
   isValidStellarAddress,
   normalizeStellarAddress,
@@ -52,10 +53,22 @@ export function getHorizonCircuitBreakerMetrics(): ReturnType<
 
 async function loadAccountFromHorizon(address: string) {
   const server = getHorizonServer();
-  // SDK typings expose AccountResponse; runtime payload includes sponsorship fields.
-  return server.loadAccount(address) as unknown as Promise<
-    Horizon.ServerApi.AccountRecord
-  >;
+  // Span name carries no address (issue #203); the account is a G-address.
+  return withSpan(
+    "horizon.loadAccount",
+    () =>
+      // SDK typings expose AccountResponse; runtime payload includes sponsorship fields.
+      server.loadAccount(address) as unknown as Promise<
+        Horizon.ServerApi.AccountRecord
+      >,
+    {
+      attributes: {
+        "peer.service": "horizon",
+        "horizon.url":
+          process.env.NEXT_PUBLIC_HORIZON_URL?.trim() || DEFAULT_HORIZON_URL,
+      },
+    },
+  );
 }
 
 /** True when the balance line is a trustline for the requested asset. */

--- a/src/lib/maintenance.ts
+++ b/src/lib/maintenance.ts
@@ -1,0 +1,96 @@
+/**
+ * Authenticated maintenance mode (issue #202).
+ *
+ * When maintenance mode is on:
+ *   - a banner is shown on every page (see src/components/MaintenanceBanner.tsx)
+ *   - mutating API requests (POST/PUT/PATCH/DELETE) get a 503 from the
+ *     middleware, except for the bypass prefixes below
+ *   - reads (GET/HEAD) keep working
+ *   - GET /api/health keeps returning 200 (see docs/DEPLOYMENT.md)
+ *
+ * The kill switch is the `MAINTENANCE` env var. It is intentionally env-only so
+ * a broken database can never lock maintainers out of turning it back off. The
+ * `maintenance_mode` feature flag is an additional, DB-backed toggle for
+ * operators who have the DB flag source enabled.
+ *
+ * This module has NO `server-only` import and NO Prisma import at the top level
+ * so the synchronous helpers can run inside the Edge middleware runtime.
+ */
+
+const TRUTHY = new Set(["1", "true", "on", "yes", "enabled"]);
+
+/** Edge-safe: env var only, no database. Used by the middleware. */
+export function isMaintenanceModeFromEnv(): boolean {
+  const raw = process.env.MAINTENANCE?.trim().toLowerCase();
+  return raw ? TRUTHY.has(raw) : false;
+}
+
+export function getMaintenanceMessage(): string {
+  return (
+    process.env.MAINTENANCE_MESSAGE?.trim() ||
+    "TrustBridge is in maintenance mode. Reads are available; changes are temporarily disabled."
+  );
+}
+
+/**
+ * Path prefixes that keep accepting requests during maintenance even when the
+ * method is mutating:
+ *   - `/api/auth`     — NextAuth callbacks must keep working
+ *   - `/api/webhooks` — GitHub / trustbridge-action deliveries are retried a
+ *                       limited number of times; dropping them loses data
+ *   - `/api/health`   — probes
+ *   - `/api/check`    — a pure Horizon read that uses POST only to keep the
+ *                       G-address out of the URL / logs; it is on the critical
+ *                       registration path, so treat it as a read
+ *
+ * Scheduled jobs (cron) are not routed through the middleware and continue to
+ * run; document any that must be paused separately. See docs/DEPLOYMENT.md.
+ */
+export const MAINTENANCE_BYPASS_PREFIXES = [
+  "/api/auth",
+  "/api/webhooks",
+  "/api/health",
+  "/api/check",
+] as const;
+
+export function isMaintenanceBypassPath(pathname: string): boolean {
+  return MAINTENANCE_BYPASS_PREFIXES.some(
+    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
+  );
+}
+
+const MUTATING_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+
+export function isMutatingMethod(method: string | undefined): boolean {
+  return method ? MUTATING_METHODS.has(method.toUpperCase()) : false;
+}
+
+/**
+ * Whether the middleware should reject this request with a 503.
+ * True only for mutating API requests that are not on a bypass prefix.
+ */
+export function shouldBlockForMaintenance(
+  method: string | undefined,
+  pathname: string,
+): boolean {
+  if (!isMaintenanceModeFromEnv()) return false;
+  if (!pathname.startsWith("/api")) return false;
+  if (!isMutatingMethod(method)) return false;
+  if (isMaintenanceBypassPath(pathname)) return false;
+  return true;
+}
+
+/**
+ * Node-runtime check that also consults the `maintenance_mode` feature flag.
+ * Used by the banner / server components. The dynamic import keeps the
+ * `server-only` feature-flags module (and Prisma) out of the Edge bundle.
+ */
+export async function isMaintenanceMode(): Promise<boolean> {
+  if (isMaintenanceModeFromEnv()) return true;
+  try {
+    const { isFeatureEnabled } = await import("@/lib/feature-flags");
+    return await isFeatureEnabled("maintenance_mode");
+  } catch {
+    return false;
+  }
+}

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -2,6 +2,8 @@ import "server-only";
 
 import { PrismaClient } from "@prisma/client";
 
+import { isTracingEnabled, withSpan } from "@/lib/tracing";
+
 const globalForPrisma = globalThis as unknown as {
   prisma: PrismaClient | undefined;
 };
@@ -14,6 +16,24 @@ export const prisma =
         ? ["query", "error", "warn"]
         : ["error"],
   });
+
+// Opt-in query spans (issue #203). The middleware is registered once per
+// client instance; the check is a cheap env read when tracing is off.
+const tracedClient = prisma as PrismaClient & { __tracingMiddleware?: boolean };
+if (!tracedClient.__tracingMiddleware) {
+  tracedClient.__tracingMiddleware = true;
+  prisma.$use(async (params, next) => {
+    if (!isTracingEnabled()) return next(params);
+    const model = params.model ?? "raw";
+    return withSpan(`prisma.${model}.${params.action}`, () => next(params), {
+      attributes: {
+        "db.system": "postgresql",
+        "db.model": model,
+        "db.operation": params.action,
+      },
+    });
+  });
+}
 
 if (process.env.NODE_ENV !== "production") {
   globalForPrisma.prisma = prisma;

--- a/src/lib/tracing.ts
+++ b/src/lib/tracing.ts
@@ -1,0 +1,166 @@
+/**
+ * Opt-in tracing for API routes, Prisma and Horizon (issue #203).
+ *
+ * Default OFF. Enabled by either:
+ *   - `OTEL_TRACES_ENABLED` truthy, or
+ *   - the `otel_traces` feature flag (env-only resolution, so the Edge runtime
+ *     is never dragged in here)
+ *
+ * When enabled and `@opentelemetry/api` is installed, spans are emitted through
+ * the real OTEL API (bridge to any OTLP collector via the standard SDK env
+ * vars). Otherwise spans are emitted as structured `trace` logs so incident
+ * responders can still see which hop is slow without standing up a collector —
+ * and the test suite needs neither.
+ *
+ * PII rules:
+ *   - span names are scrubbed of Stellar addresses / emails ("No addresses in
+ *     span names")
+ *   - span attributes are run through the Sentry redactor before they leave
+ *     the process
+ */
+
+import { StructuredLogger } from "@/lib/logger";
+import { redactValue } from "@/lib/sentry";
+
+const TRUTHY = new Set(["1", "true", "on", "yes", "enabled"]);
+
+function envEnabled(): boolean {
+  const raw = process.env.OTEL_TRACES_ENABLED?.trim().toLowerCase();
+  if (raw && TRUTHY.has(raw)) return true;
+  // `otel_traces` flag, env-only resolution (no DB, no server-only import).
+  const flag = process.env.FEATURE_FLAG_OTEL_TRACES?.trim().toLowerCase();
+  return flag ? TRUTHY.has(flag) : false;
+}
+
+export function isTracingEnabled(): boolean {
+  return envEnabled();
+}
+
+const STELLAR_KEY = /\b[GS][A-Z2-7]{55}\b/g;
+const EMAIL = /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g;
+
+/** Strip addresses / emails so they can never end up in a span name. */
+export function sanitizeSpanName(name: string): string {
+  return name
+    .replace(STELLAR_KEY, "{address}")
+    .replace(EMAIL, "{email}")
+    .slice(0, 200);
+}
+
+export function redactSpanAttributes(
+  attributes?: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+  if (!attributes) return undefined;
+  return redactValue(attributes, 0) as Record<string, unknown>;
+}
+
+const traceLogger = new StructuredLogger("trace");
+
+/** Minimal structural view of the parts of the OTEL API we use. */
+interface OtelSpan {
+  setAttributes(attributes: Record<string, unknown>): void;
+  setStatus(status: { code: number; message?: string }): void;
+  end(): void;
+}
+interface OtelTracer {
+  startActiveSpan<T>(
+    name: string,
+    fn: (span: OtelSpan) => Promise<T>,
+  ): Promise<T>;
+}
+interface OtelApiModule {
+  trace?: { getTracer?: (name: string) => OtelTracer };
+  default?: OtelApiModule;
+}
+
+// Lazily resolve the optional OpenTelemetry API. The specifier is held in a
+// variable so bundlers don't try to resolve a package that may not be
+// installed; a missing module rejects and we fall back to log spans.
+let otelTracerPromise: Promise<OtelTracer | null> | null = null;
+function loadOtelTracer(): Promise<OtelTracer | null> {
+  if (!otelTracerPromise) {
+    const specifier = "@opentelemetry/api";
+    otelTracerPromise = import(
+      /* @vite-ignore */ /* webpackIgnore: true */ specifier
+    )
+      .then((mod: OtelApiModule) => {
+        const api = mod?.trace ? mod : mod?.default;
+        const getTracer = api?.trace?.getTracer;
+        if (!getTracer) return null;
+        return getTracer(
+          process.env.OTEL_SERVICE_NAME || "trustbridge-dashboard",
+        );
+      })
+      .catch(() => null);
+  }
+  return otelTracerPromise;
+}
+
+/** Test hook: forget the resolved OTEL tracer. */
+export function resetTracingForTests(): void {
+  otelTracerPromise = null;
+}
+
+export interface SpanOptions {
+  attributes?: Record<string, unknown>;
+}
+
+/**
+ * Run `fn` inside a span. A no-op passthrough when tracing is disabled, so it
+ * is safe to wrap hot paths unconditionally.
+ */
+export async function withSpan<T>(
+  name: string,
+  fn: () => Promise<T> | T,
+  options: SpanOptions = {},
+): Promise<T> {
+  if (!isTracingEnabled()) {
+    return fn();
+  }
+
+  const spanName = sanitizeSpanName(name);
+  const attributes = redactSpanAttributes(options.attributes);
+  const start = Date.now();
+
+  const otel = await loadOtelTracer();
+  if (otel) {
+    return otel.startActiveSpan(spanName, async (span) => {
+      try {
+        if (attributes) span.setAttributes(attributes);
+        const result = await fn();
+        span.setStatus({ code: 1 });
+        return result;
+      } catch (error) {
+        span.setStatus({
+          code: 2,
+          message:
+            error instanceof Error ? sanitizeSpanName(error.message) : "error",
+        });
+        throw error;
+      } finally {
+        span.end();
+      }
+    });
+  }
+
+  try {
+    const result = await fn();
+    traceLogger.debug("span", {
+      name: spanName,
+      durationMs: Date.now() - start,
+      ok: true,
+      attributes,
+    });
+    return result;
+  } catch (error) {
+    traceLogger.error("span_error", {
+      name: spanName,
+      durationMs: Date.now() - start,
+      ok: false,
+      error:
+        error instanceof Error ? sanitizeSpanName(error.message) : "error",
+      attributes,
+    });
+    throw error;
+  }
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,6 +2,10 @@ import { withAuth } from "next-auth/middleware";
 import { NextResponse } from "next/server";
 
 import { recordAuditLog } from "@/lib/audit";
+import {
+  getMaintenanceMessage,
+  shouldBlockForMaintenance,
+} from "@/lib/maintenance";
 
 /**
  * RBAC path rules (default deny):
@@ -18,6 +22,21 @@ export default withAuth(
     const isMaintainer = token?.isMaintainer;
     const role = (token?.role as string | undefined) ?? (isMaintainer ? "viewer" : undefined);
     const path = req.nextUrl.pathname;
+
+    // Maintenance mode (issue #202): during a deploy, mutating API requests are
+    // rejected with a 503 while reads stay up. `/api/auth`, `/api/webhooks` and
+    // `/api/health` are exempt (see src/lib/maintenance.ts). The kill switch is
+    // the env var only, so a bad DB can't strand maintainers.
+    //
+    // Deliberately no audit write here: maintenance mode often coincides with a
+    // migration, and a blocked client retrying would amplify writes against a
+    // database that may be mid-deploy. The 503 response is the signal.
+    if (shouldBlockForMaintenance(req.method, path)) {
+      return NextResponse.json(
+        { error: "maintenance_mode", message: getMaintenanceMessage() },
+        { status: 503, headers: { "Retry-After": "120" } }
+      );
+    }
 
     // /dashboard requires viewer+
     if (path.startsWith("/dashboard")) {
@@ -71,5 +90,14 @@ export default withAuth(
 );
 
 export const config = {
-  matcher: ["/dashboard/:path*", "/register/:path*", "/api/invites/:path*"],
+  // `/api/:path*` is matched so maintenance mode can 503 mutating API calls.
+  // The `authorized` callback returns true for API paths, so this does not add
+  // an auth gate — each route keeps doing its own authorization.
+  matcher: [
+    "/dashboard/:path*",
+    "/register/:path*",
+    // All API routes except NextAuth's own endpoints, so maintenance mode can
+    // 503 mutating calls without wrapping the auth flow.
+    "/api/((?!auth).*)",
+  ],
 };

--- a/tests/api/queue-dlq.test.ts
+++ b/tests/api/queue-dlq.test.ts
@@ -1,0 +1,175 @@
+/**
+ * API tests for the dead-letter queue routes (issue #200).
+ *
+ *  - GET  /api/contributors/queue/dlq                 — list failed jobs
+ *  - POST /api/contributors/queue/dlq/[jobId]/retry   — re-queue a failed job
+ *
+ * Both are maintainer-only. Retry is additionally CSRF-guarded, gated behind
+ * the `dlq_retry` feature flag, and audited.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/api-auth");
+vi.mock("@/lib/queue-worker");
+vi.mock("@/lib/audit", () => ({ recordAuditLog: vi.fn() }));
+vi.mock("@/lib/feature-flags", () => ({ isFeatureEnabled: vi.fn() }));
+
+import * as authLib from "@/lib/api-auth";
+import * as queueLib from "@/lib/queue-worker";
+import { recordAuditLog } from "@/lib/audit";
+import { isFeatureEnabled } from "@/lib/feature-flags";
+
+const SESSION = {
+  user: { id: "maintainer-1", githubUsername: "alice" },
+} as never;
+
+function get(path = "/api/contributors/queue/dlq") {
+  return new Request(`http://localhost:3000${path}`);
+}
+
+function retryReq(jobId: string) {
+  return new NextRequest(
+    `http://localhost:3000/api/contributors/queue/dlq/${jobId}/retry`,
+    {
+      method: "POST",
+      headers: { origin: "http://localhost:3000", host: "localhost:3000" },
+    },
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(isFeatureEnabled).mockResolvedValue(true);
+});
+
+describe("GET /api/contributors/queue/dlq", () => {
+  it("is maintainer-only", async () => {
+    vi.mocked(authLib.requireMaintainerSession).mockResolvedValue(null);
+    const { GET } = await import("@/app/api/contributors/queue/dlq/route");
+    const res = await GET(get());
+    expect(res.status).toBe(403);
+    expect(vi.mocked(queueLib.backgroundQueue.getFailedJobs)).not.toHaveBeenCalled();
+  });
+
+  it("returns the failed jobs with a stable shape", async () => {
+    vi.mocked(authLib.requireMaintainerSession).mockResolvedValue(SESSION);
+    vi.mocked(queueLib.backgroundQueue.getFailedJobs).mockResolvedValue([
+      {
+        id: "job-1",
+        type: "recheck.single",
+        status: "failed",
+        data: { __retries: 2 },
+        error: "Horizon error: timeout",
+        createdAt: new Date("2026-08-29T10:00:00Z"),
+        startedAt: new Date("2026-08-29T10:00:01Z"),
+        completedAt: new Date("2026-08-29T10:00:05Z"),
+      },
+    ] as never);
+
+    const { GET } = await import("@/app/api/contributors/queue/dlq/route");
+    const res = await GET(get());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.count).toBe(1);
+    expect(body.jobs[0]).toMatchObject({
+      id: "job-1",
+      type: "recheck.single",
+      status: "failed",
+      error: "Horizon error: timeout",
+      attempts: 2,
+    });
+  });
+
+  it("scopes the query to the caller", async () => {
+    vi.mocked(authLib.requireMaintainerSession).mockResolvedValue(SESSION);
+    vi.mocked(queueLib.backgroundQueue.getFailedJobs).mockResolvedValue([] as never);
+
+    const { GET } = await import("@/app/api/contributors/queue/dlq/route");
+    await GET(get("/api/contributors/queue/dlq?limit=10"));
+
+    expect(queueLib.backgroundQueue.getFailedJobs).toHaveBeenCalledWith({
+      limit: 10,
+      ownerId: "maintainer-1",
+    });
+  });
+});
+
+describe("POST /api/contributors/queue/dlq/[jobId]/retry", () => {
+  it("rejects cross-origin requests", async () => {
+    const { POST } = await import(
+      "@/app/api/contributors/queue/dlq/[jobId]/retry/route"
+    );
+    const req = new NextRequest(
+      "http://localhost:3000/api/contributors/queue/dlq/job-1/retry",
+      { method: "POST", headers: { origin: "https://evil.example" } },
+    );
+    const res = await POST(req, { params: { jobId: "job-1" } });
+    expect(res.status).toBe(403);
+  });
+
+  it("is maintainer-only", async () => {
+    vi.mocked(authLib.requireMaintainerSession).mockResolvedValue(null);
+    const { POST } = await import(
+      "@/app/api/contributors/queue/dlq/[jobId]/retry/route"
+    );
+    const res = await POST(retryReq("job-1"), { params: { jobId: "job-1" } });
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 403 when the dlq_retry flag is off", async () => {
+    vi.mocked(authLib.requireMaintainerSession).mockResolvedValue(SESSION);
+    vi.mocked(isFeatureEnabled).mockResolvedValue(false);
+
+    const { POST } = await import(
+      "@/app/api/contributors/queue/dlq/[jobId]/retry/route"
+    );
+    const res = await POST(retryReq("job-1"), { params: { jobId: "job-1" } });
+    expect(res.status).toBe(403);
+    expect(vi.mocked(queueLib.backgroundQueue.retryJob)).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the job is not retryable", async () => {
+    vi.mocked(authLib.requireMaintainerSession).mockResolvedValue(SESSION);
+    vi.mocked(queueLib.backgroundQueue.retryJob).mockResolvedValue(null);
+
+    const { POST } = await import(
+      "@/app/api/contributors/queue/dlq/[jobId]/retry/route"
+    );
+    const res = await POST(retryReq("missing"), { params: { jobId: "missing" } });
+    expect(res.status).toBe(404);
+  });
+
+  it("re-queues the job and writes an audit log", async () => {
+    vi.mocked(authLib.requireMaintainerSession).mockResolvedValue(SESSION);
+    vi.mocked(queueLib.backgroundQueue.retryJob).mockResolvedValue({
+      id: "job-1",
+      type: "recheck.batch",
+      status: "pending",
+    } as never);
+
+    const { POST } = await import(
+      "@/app/api/contributors/queue/dlq/[jobId]/retry/route"
+    );
+    const res = await POST(retryReq("job-1"), { params: { jobId: "job-1" } });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.job).toEqual({
+      id: "job-1",
+      type: "recheck.batch",
+      status: "pending",
+    });
+    expect(queueLib.backgroundQueue.retryJob).toHaveBeenCalledWith("job-1", {
+      ownerId: "maintainer-1",
+    });
+    expect(recordAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "queue.job.retried",
+        actorId: "maintainer-1",
+        targetId: "job-1",
+      }),
+    );
+  });
+});

--- a/tests/unit/background-queue-dlq.test.ts
+++ b/tests/unit/background-queue-dlq.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Unit tests for the dead-letter-queue additions to BackgroundQueue (issue #200):
+ * error size cap + PII redaction, getFailedJobs, retryJob.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    queueJob: {
+      findMany: vi.fn(),
+      findUnique: vi.fn(),
+      update: vi.fn(),
+      create: vi.fn(),
+      count: vi.fn(),
+    },
+  },
+}));
+
+import { prisma } from "@/lib/prisma";
+import {
+  MAX_ERROR_LENGTH,
+  backgroundQueue,
+  sanitizeJobError,
+} from "@/lib/background-queue";
+
+const findMany = vi.mocked(prisma.queueJob.findMany);
+const findUnique = vi.mocked(prisma.queueJob.findUnique);
+const update = vi.mocked(prisma.queueJob.update);
+
+const SAMPLE_ADDRESS = "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("sanitizeJobError", () => {
+  it("redacts a Stellar address from the message", () => {
+    const out = sanitizeJobError(`account ${SAMPLE_ADDRESS} not found`);
+    expect(out).not.toContain(SAMPLE_ADDRESS);
+    expect(out).toContain("redacted:stellar-address");
+  });
+
+  it("caps the length", () => {
+    const out = sanitizeJobError("x".repeat(MAX_ERROR_LENGTH + 5000));
+    expect(out.length).toBeLessThanOrEqual(MAX_ERROR_LENGTH + 20);
+    expect(out.endsWith("…[truncated]")).toBe(true);
+  });
+
+  it("leaves a short benign message untouched", () => {
+    expect(sanitizeJobError("Horizon connection timeout")).toBe(
+      "Horizon connection timeout",
+    );
+  });
+});
+
+describe("getFailedJobs", () => {
+  it("queries only failed jobs, newest first, capped at 200", async () => {
+    findMany.mockResolvedValue([] as never);
+    await backgroundQueue.getFailedJobs({ limit: 9999 });
+
+    expect(findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { status: "failed" },
+        orderBy: { completedAt: "desc" },
+        take: 200,
+      }),
+    );
+  });
+
+  it("scopes to the owner plus ownerless jobs", async () => {
+    findMany.mockResolvedValue([] as never);
+    await backgroundQueue.getFailedJobs({ ownerId: "user-1" });
+
+    expect(findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          status: "failed",
+          OR: [{ ownerId: "user-1" }, { ownerId: null }],
+        },
+      }),
+    );
+  });
+
+  it("maps rows into the Job shape", async () => {
+    findMany.mockResolvedValue([
+      {
+        id: "j1",
+        type: "recheck.single",
+        status: "failed",
+        data: { __retries: 1 },
+        result: null,
+        error: "boom",
+        ownerId: "user-1",
+        createdAt: new Date(),
+        startedAt: new Date(),
+        completedAt: new Date(),
+      },
+    ] as never);
+
+    const jobs = await backgroundQueue.getFailedJobs();
+    expect(jobs[0]).toMatchObject({ id: "j1", status: "failed", error: "boom" });
+  });
+});
+
+describe("retryJob", () => {
+  it("returns null when the job does not exist", async () => {
+    findUnique.mockResolvedValue(null);
+    expect(await backgroundQueue.retryJob("nope")).toBeNull();
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it("returns null when the job is not in the failed state", async () => {
+    findUnique.mockResolvedValue({ id: "j1", status: "completed" } as never);
+    expect(await backgroundQueue.retryJob("j1")).toBeNull();
+  });
+
+  it("returns null when the job belongs to another owner", async () => {
+    findUnique.mockResolvedValue({
+      id: "j1",
+      status: "failed",
+      ownerId: "someone-else",
+      data: {},
+    } as never);
+    expect(
+      await backgroundQueue.retryJob("j1", { ownerId: "user-1" }),
+    ).toBeNull();
+  });
+
+  it("resets a failed job to pending and bumps the retry count", async () => {
+    findUnique.mockResolvedValue({
+      id: "j1",
+      type: "recheck.batch",
+      status: "failed",
+      ownerId: "user-1",
+      data: { __retries: 2 },
+      result: null,
+      error: "boom",
+      createdAt: new Date(),
+      startedAt: new Date(),
+      completedAt: new Date(),
+    } as never);
+    update.mockImplementation((async (args: { data: unknown }) => ({
+      id: "j1",
+      type: "recheck.batch",
+      status: "pending",
+      ownerId: "user-1",
+      data: (args.data as { data: unknown }).data,
+      result: null,
+      error: null,
+      createdAt: new Date(),
+      startedAt: null,
+      completedAt: null,
+    })) as never);
+
+    const job = await backgroundQueue.retryJob("j1", { ownerId: "user-1" });
+    expect(job?.status).toBe("pending");
+
+    const updateArg = update.mock.calls[0][0] as {
+      data: { status: string; error: null; data: { __retries: number } };
+    };
+    expect(updateArg.data.status).toBe("pending");
+    expect(updateArg.data.error).toBeNull();
+    expect(updateArg.data.data.__retries).toBe(3);
+  });
+});

--- a/tests/unit/feature-flags.test.ts
+++ b/tests/unit/feature-flags.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Unit tests for the feature-flags module (issue #201).
+ *
+ * Covers the resolution order (env override → DB row → built-in default),
+ * the fail-closed behaviour for risky flags when the DB source is unreadable,
+ * and the in-process cache.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    featureFlag: {
+      findMany: vi.fn(),
+      upsert: vi.fn(),
+    },
+  },
+}));
+
+import { prisma } from "@/lib/prisma";
+import {
+  clearFeatureFlagCache,
+  getAllFeatureFlags,
+  isFeatureEnabled,
+  isFeatureEnabledFromEnv,
+  setFeatureFlag,
+} from "@/lib/feature-flags";
+
+const findMany = vi.mocked(prisma.featureFlag.findMany);
+const upsert = vi.mocked(prisma.featureFlag.upsert);
+
+const ORIGINAL_ENV = process.env;
+
+beforeEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+  delete process.env.FEATURE_FLAGS_DB_ENABLED;
+  delete process.env.FEATURE_FLAG_BATCH_RECHECK;
+  delete process.env.FEATURE_FLAG_OTEL_TRACES;
+  delete process.env.FEATURE_FLAG_DLQ_RETRY;
+  clearFeatureFlagCache();
+  vi.clearAllMocks();
+  findMany.mockResolvedValue([]);
+});
+
+afterEach(() => {
+  process.env = ORIGINAL_ENV;
+});
+
+describe("built-in defaults", () => {
+  it("returns the default when there is no env override and no DB source", async () => {
+    expect(await isFeatureEnabled("batch_recheck")).toBe(true);
+    expect(await isFeatureEnabled("otel_traces")).toBe(false);
+    expect(findMany).not.toHaveBeenCalled();
+  });
+
+  it("returns false for an unknown flag", async () => {
+    // @ts-expect-error deliberately passing an unknown key
+    expect(await isFeatureEnabled("nope")).toBe(false);
+  });
+});
+
+describe("env overrides", () => {
+  it("an env override wins over the default and is not a DB read", async () => {
+    process.env.FEATURE_FLAG_BATCH_RECHECK = "off";
+    expect(await isFeatureEnabled("batch_recheck")).toBe(false);
+
+    process.env.FEATURE_FLAG_OTEL_TRACES = "1";
+    expect(await isFeatureEnabled("otel_traces")).toBe(true);
+
+    expect(findMany).not.toHaveBeenCalled();
+  });
+
+  it("isFeatureEnabledFromEnv ignores the DB entirely", () => {
+    process.env.FEATURE_FLAGS_DB_ENABLED = "1";
+    process.env.FEATURE_FLAG_DLQ_RETRY = "false";
+    expect(isFeatureEnabledFromEnv("dlq_retry")).toBe(false);
+    expect(isFeatureEnabledFromEnv("batch_recheck")).toBe(true); // default
+    expect(findMany).not.toHaveBeenCalled();
+  });
+
+  it("an unrecognised env value falls through to the next source", async () => {
+    process.env.FEATURE_FLAG_BATCH_RECHECK = "maybe";
+    expect(await isFeatureEnabled("batch_recheck")).toBe(true); // default
+  });
+});
+
+describe("database source", () => {
+  beforeEach(() => {
+    process.env.FEATURE_FLAGS_DB_ENABLED = "true";
+  });
+
+  it("uses the DB row when present", async () => {
+    findMany.mockResolvedValue([
+      { key: "otel_traces", enabled: true },
+      { key: "batch_recheck", enabled: false },
+    ] as never);
+
+    expect(await isFeatureEnabled("otel_traces")).toBe(true);
+    expect(await isFeatureEnabled("batch_recheck")).toBe(false);
+  });
+
+  it("falls back to the default when the DB has no row", async () => {
+    findMany.mockResolvedValue([] as never);
+    expect(await isFeatureEnabled("batch_recheck")).toBe(true);
+  });
+
+  it("caches the DB read within the TTL and re-reads after clear", async () => {
+    findMany.mockResolvedValue([{ key: "otel_traces", enabled: true }] as never);
+
+    await isFeatureEnabled("otel_traces");
+    await isFeatureEnabled("batch_recheck");
+    expect(findMany).toHaveBeenCalledTimes(1);
+
+    clearFeatureFlagCache();
+    await isFeatureEnabled("otel_traces");
+    expect(findMany).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("fail closed", () => {
+  beforeEach(() => {
+    process.env.FEATURE_FLAGS_DB_ENABLED = "1";
+    findMany.mockRejectedValue(new Error("connection refused"));
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  it("resolves a risky flag to false when the DB source is unreadable", async () => {
+    expect(await isFeatureEnabled("batch_recheck")).toBe(false);
+    expect(await isFeatureEnabled("dlq_retry")).toBe(false);
+    expect(await isFeatureEnabled("maintenance_mode")).toBe(false);
+  });
+
+  it("resolves a non-risky flag to its default when the DB is unreadable", async () => {
+    expect(await isFeatureEnabled("otel_traces")).toBe(false); // default false
+  });
+
+  it("still honours an env override even when the DB is down", async () => {
+    process.env.FEATURE_FLAG_BATCH_RECHECK = "on";
+    expect(await isFeatureEnabled("batch_recheck")).toBe(true);
+  });
+});
+
+describe("getAllFeatureFlags", () => {
+  it("reports every known flag with its source", async () => {
+    process.env.FEATURE_FLAG_OTEL_TRACES = "1";
+    const all = await getAllFeatureFlags();
+    const keys = all.map((f) => f.key).sort();
+    expect(keys).toEqual(
+      [
+        "batch_recheck",
+        "dlq_retry",
+        "invite_generation",
+        "maintenance_mode",
+        "otel_traces",
+      ].sort(),
+    );
+    expect(all.find((f) => f.key === "otel_traces")?.source).toBe("env");
+    expect(all.find((f) => f.key === "batch_recheck")?.source).toBe("default");
+  });
+});
+
+describe("setFeatureFlag", () => {
+  it("throws when the DB source is disabled", async () => {
+    await expect(setFeatureFlag("otel_traces", true)).rejects.toThrow(
+      /FEATURE_FLAGS_DB_ENABLED/,
+    );
+    expect(upsert).not.toHaveBeenCalled();
+  });
+
+  it("upserts and clears the cache when the DB source is enabled", async () => {
+    process.env.FEATURE_FLAGS_DB_ENABLED = "1";
+    upsert.mockResolvedValue({} as never);
+    await setFeatureFlag("otel_traces", true, "user-1");
+    expect(upsert).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { key: "otel_traces" } }),
+    );
+  });
+});

--- a/tests/unit/middleware-maintenance.test.ts
+++ b/tests/unit/middleware-maintenance.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Maintenance-mode middleware unit tests (issue #202).
+ *
+ * `npm test -- middleware` picks this file up alongside middleware.test.ts.
+ *
+ * Verifies:
+ *  - reads (GET/HEAD) are never blocked
+ *  - mutating API requests are blocked only while MAINTENANCE is truthy
+ *  - /api/auth, /api/webhooks and /api/health are exempt
+ *  - non-API paths are untouched
+ *  - the env var is the only signal the sync helper reads (no DB)
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  isMaintenanceBypassPath,
+  isMaintenanceModeFromEnv,
+  isMutatingMethod,
+  shouldBlockForMaintenance,
+} from "@/lib/maintenance";
+
+const ORIGINAL_ENV = process.env;
+
+beforeEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+  delete process.env.MAINTENANCE;
+  delete process.env.MAINTENANCE_MESSAGE;
+});
+
+afterEach(() => {
+  process.env = ORIGINAL_ENV;
+});
+
+describe("isMaintenanceModeFromEnv", () => {
+  it("is false when unset", () => {
+    expect(isMaintenanceModeFromEnv()).toBe(false);
+  });
+
+  it.each(["1", "true", "on", "YES", "enabled"])(
+    "is true for %s",
+    (value) => {
+      process.env.MAINTENANCE = value;
+      expect(isMaintenanceModeFromEnv()).toBe(true);
+    },
+  );
+
+  it.each(["0", "false", "off", "", "no"])("is false for %s", (value) => {
+    process.env.MAINTENANCE = value;
+    expect(isMaintenanceModeFromEnv()).toBe(false);
+  });
+});
+
+describe("isMutatingMethod", () => {
+  it("classifies verbs", () => {
+    expect(isMutatingMethod("POST")).toBe(true);
+    expect(isMutatingMethod("put")).toBe(true);
+    expect(isMutatingMethod("PATCH")).toBe(true);
+    expect(isMutatingMethod("DELETE")).toBe(true);
+    expect(isMutatingMethod("GET")).toBe(false);
+    expect(isMutatingMethod("HEAD")).toBe(false);
+    expect(isMutatingMethod(undefined)).toBe(false);
+  });
+});
+
+describe("isMaintenanceBypassPath", () => {
+  it("matches the exact prefix and sub-paths", () => {
+    expect(isMaintenanceBypassPath("/api/auth")).toBe(true);
+    expect(isMaintenanceBypassPath("/api/auth/callback/github")).toBe(true);
+    expect(isMaintenanceBypassPath("/api/webhooks/github-org-membership")).toBe(
+      true,
+    );
+    expect(isMaintenanceBypassPath("/api/health")).toBe(true);
+    expect(isMaintenanceBypassPath("/api/check")).toBe(true);
+  });
+
+  it("does not match unrelated paths", () => {
+    expect(isMaintenanceBypassPath("/api/contributors")).toBe(false);
+    expect(isMaintenanceBypassPath("/api/authenticate")).toBe(false);
+  });
+});
+
+describe("shouldBlockForMaintenance", () => {
+  it("never blocks when maintenance mode is off", () => {
+    expect(shouldBlockForMaintenance("POST", "/api/contributors")).toBe(false);
+  });
+
+  describe("with MAINTENANCE=1", () => {
+    beforeEach(() => {
+      process.env.MAINTENANCE = "1";
+    });
+
+    it("blocks mutating API requests", () => {
+      expect(shouldBlockForMaintenance("POST", "/api/contributors")).toBe(true);
+      expect(shouldBlockForMaintenance("DELETE", "/api/invites")).toBe(true);
+    });
+
+    it("allows reads through", () => {
+      expect(shouldBlockForMaintenance("GET", "/api/contributors")).toBe(false);
+      expect(shouldBlockForMaintenance("HEAD", "/api/health")).toBe(false);
+    });
+
+    it("allows webhooks, auth, health and check through", () => {
+      expect(
+        shouldBlockForMaintenance("POST", "/api/webhooks/trustbridge-action"),
+      ).toBe(false);
+      expect(shouldBlockForMaintenance("POST", "/api/auth/signin")).toBe(false);
+      expect(shouldBlockForMaintenance("POST", "/api/health")).toBe(false);
+      expect(shouldBlockForMaintenance("POST", "/api/check")).toBe(false);
+    });
+
+    it("ignores non-API paths", () => {
+      expect(shouldBlockForMaintenance("POST", "/dashboard")).toBe(false);
+    });
+  });
+});

--- a/tests/unit/tracing.test.ts
+++ b/tests/unit/tracing.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Unit tests for the opt-in tracing module (issue #203).
+ *
+ * No collector required. Verifies: default-off passthrough, PII redaction of
+ * span attributes, address/email scrubbing from span names, and error
+ * propagation.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  isTracingEnabled,
+  redactSpanAttributes,
+  resetTracingForTests,
+  sanitizeSpanName,
+  withSpan,
+} from "@/lib/tracing";
+
+const ORIGINAL_ENV = process.env;
+const SAMPLE_ADDRESS = "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN";
+
+beforeEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+  delete process.env.OTEL_TRACES_ENABLED;
+  delete process.env.FEATURE_FLAG_OTEL_TRACES;
+  delete process.env.DEBUG;
+  resetTracingForTests();
+  vi.restoreAllMocks();
+});
+
+afterEach(() => {
+  process.env = ORIGINAL_ENV;
+});
+
+describe("isTracingEnabled", () => {
+  it("is off by default", () => {
+    expect(isTracingEnabled()).toBe(false);
+  });
+
+  it("is on with OTEL_TRACES_ENABLED truthy", () => {
+    process.env.OTEL_TRACES_ENABLED = "1";
+    expect(isTracingEnabled()).toBe(true);
+  });
+
+  it("is on with the otel_traces env flag", () => {
+    process.env.FEATURE_FLAG_OTEL_TRACES = "true";
+    expect(isTracingEnabled()).toBe(true);
+  });
+});
+
+describe("sanitizeSpanName", () => {
+  it("strips Stellar addresses", () => {
+    expect(sanitizeSpanName(`horizon.loadAccount ${SAMPLE_ADDRESS}`)).toBe(
+      "horizon.loadAccount {address}",
+    );
+  });
+
+  it("strips emails", () => {
+    expect(sanitizeSpanName("email.send to alice@example.com")).toBe(
+      "email.send to {email}",
+    );
+  });
+
+  it("caps length", () => {
+    expect(sanitizeSpanName("x".repeat(500)).length).toBe(200);
+  });
+});
+
+describe("redactSpanAttributes", () => {
+  it("redacts addresses and tokens but keeps benign values", () => {
+    const out = redactSpanAttributes({
+      "horizon.url": "https://horizon.stellar.org",
+      address: SAMPLE_ADDRESS,
+      note: "hello",
+    });
+    expect(out?.["horizon.url"]).toBe("https://horizon.stellar.org");
+    expect(out?.note).toBe("hello");
+    expect(String(out?.address)).toContain("redacted");
+  });
+
+  it("returns undefined for no attributes", () => {
+    expect(redactSpanAttributes(undefined)).toBeUndefined();
+  });
+});
+
+describe("withSpan (disabled)", () => {
+  it("is a transparent passthrough and emits nothing", async () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const fn = vi.fn().mockResolvedValue(42);
+
+    await expect(withSpan("api.check", fn)).resolves.toBe(42);
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(logSpy).not.toHaveBeenCalled();
+    expect(errSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("withSpan (enabled)", () => {
+  beforeEach(() => {
+    process.env.OTEL_TRACES_ENABLED = "1";
+    process.env.DEBUG = "1";
+  });
+
+  it("returns the wrapped value and logs a span", async () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await expect(withSpan("prisma.User.findMany", () => "ok")).resolves.toBe(
+      "ok",
+    );
+
+    const payloads = logSpy.mock.calls.map((c) => String(c[0]));
+    expect(payloads.some((p) => p.includes('"span"'))).toBe(true);
+    expect(payloads.some((p) => p.includes("prisma.User.findMany"))).toBe(true);
+  });
+
+  it("propagates errors and never leaks an address into the log", async () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(
+      withSpan(
+        `horizon.loadAccount ${SAMPLE_ADDRESS}`,
+        () => {
+          throw new Error(`account ${SAMPLE_ADDRESS} not found`);
+        },
+        { attributes: { address: SAMPLE_ADDRESS } },
+      ),
+    ).rejects.toThrow(/not found/);
+
+    const logged = errSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(logged).not.toContain(SAMPLE_ADDRESS);
+    expect(logged).toContain("{address}");
+  });
+});


### PR DESCRIPTION
Closes #200, closes #201, closes #202, closes #203.

Four ops/observability features that share plumbing (the feature-flags module gates the others), delivered together.

---

## #200 — Dead-letter queue UI for failed rechecks/emails

- `BackgroundQueue.getFailedJobs()` and `retryJob()` on the existing DB-backed queue.
- Stored job errors are now **redacted** (Sentry redactor — no addresses/tokens/emails) and **capped** at `MAX_ERROR_LENGTH` (2000).
- `GET /api/contributors/queue/dlq` — list failed jobs; `POST /api/contributors/queue/dlq/[jobId]/retry` — re-queue. Both **maintainer-only**, retry is CSRF-guarded, **owner-scoped**, and **audited** (`queue.job.retried`). Retry is additionally gated by the `dlq_retry` flag.
- Retry count tracked on `data.__retries`.
- `/dashboard/queue` page: failed jobs with error text + per-row **Retry**, empty state, refresh. Header nav link ("Failed jobs") for maintainers.

**PR checklist:** ✅ DLQ UI ✅ Retry ✅ Audit ✅ Tests

## #201 — Feature flags module (env + optional DB)

- `src/lib/feature-flags.ts`. Resolution: `FEATURE_FLAG_<KEY>` env override → `FeatureFlag` DB row (only when `FEATURE_FLAGS_DB_ENABLED`) → built-in default.
- In-process cache (`FEATURE_FLAGS_CACHE_TTL_MS`, default 30s; failed reads cached ≤5s); `clearFeatureFlagCache()` after writes.
- **Fail closed:** risky flags resolve to `false` when the DB source is enabled but unreadable.
- `FeatureFlag` model + migration. `getAllFeatureFlags()` / `setFeatureFlag()` for an optional admin UI.
- **Two existing risky writes now gated & documented:** batch recheck (`POST /api/contributors` → `batch_recheck`) and invite generation (`POST /api/invites/generate` → `invite_generation`).
- Docs: new `docs/FEATURE_FLAGS.md`, plus `docs/ENVIRONMENT.md`.

**PR checklist:** ✅ Flags ✅ Docs ✅ Tests

## #202 — Authenticated maintenance mode

- `src/lib/maintenance.ts`. `MAINTENANCE=1` (edge-safe, env-only kill switch — a broken DB can never strand maintainers) **or** the `maintenance_mode` DB flag.
- `src/middleware.ts` returns `503 {"error":"maintenance_mode"}` + `Retry-After: 120` for mutating `/api/*`; **reads stay up**. Exempt: `/api/auth`, `/api/webhooks` (deliveries not dropped), `/api/health` (still `200`), `/api/check` (pure Horizon read).
- No audit write on the block path — deliberately, to avoid write amplification against a DB that may be mid-migration.
- `MaintenanceBanner` rendered from the root layout.
- `docs/DEPLOYMENT.md`: runbook + cron / webhook / in-flight-job caveats.
- Validate: `npm test -- middleware` (`tests/unit/middleware-maintenance.test.ts`).

**PR checklist:** ✅ Mode ✅ Banner ✅ Docs

## #203 — Opt-in OpenTelemetry traces (route → Prisma → Horizon)

- `src/lib/tracing.ts`. **Default off** (`OTEL_TRACES_ENABLED` or `otel_traces` flag).
- Spans: `api.check`, `prisma.<model>.<action>` (via `$use`, no-op when disabled), `horizon.loadAccount`.
- **PII:** span names scrubbed of Stellar addresses / emails ("no addresses in span names"); attributes run through the Sentry redactor.
- Bridges to `@opentelemetry/api` when installed (honours standard `OTEL_*` collector vars, SDK owns serverless flush); otherwise emits structured `trace` log spans, so **tests need no collector**.
- `src/instrumentation.ts` + `experimental.instrumentationHook`.
- Docs: `docs/ENVIRONMENT.md`.

**PR checklist:** ✅ Opt-in traces ✅ Redaction ✅ Docs

---

## Drive-by

`src/components/WalletInstallStepper.tsx` had unescaped `"` inside JS strings and an unused var that were failing `npm run lint` **and** `npm run typecheck` on `main`. Fixed so CI on this branch is green.

## Validation

- `npm test` — **1003 passing** (+62 new: feature-flags, maintenance/middleware, tracing, DLQ API, DLQ queue methods)
- `npm run lint`, `npm run typecheck`, `npm run build` — all green
- New migration: `prisma/migrations/20260829120000_add_feature_flag_model`

🤖 Generated with [Claude Code](https://claude.com/claude-code)